### PR TITLE
[Fix] ImageUploadEditor progress bar issue

### DIFF
--- a/Serenity.Scripts/CoreLib/UI/Editors/Editors.ts
+++ b/Serenity.Scripts/CoreLib/UI/Editors/Editors.ts
@@ -1015,7 +1015,7 @@
                 buttons: this.getToolButtons()
             });
 
-            var progress = $('<div><div></div></div>')
+            this.progress = $('<div><div></div></div>')
                 .addClass('upload-progress')
                 .prependTo(this.toolbar.element);
 


### PR DESCRIPTION
Other than with the MultipleFileUploadEditor, the progress bar display is not shown with the FileUploadEditor. The bug was probably introduced when code was transfered to the getUploadInputOptions() method.