### PR TITLE
DateEditor: fixed operator for maxValue validation

### DIFF
--- a/src/Serenity.Scripts/CoreLib/UI/Editors/DateEditor.ts
+++ b/src/Serenity.Scripts/CoreLib/UI/Editors/DateEditor.ts
@@ -66,7 +66,7 @@ export class DateEditor extends Widget<any> implements IStringValue, IReadOnly {
                 return format(text('Validation.MinDate'), formatDate(this.get_minValue(), null));
             }
 
-            if (!isEmptyOrNull(this.get_maxValue()) && Invariant.stringCompare(value, this.get_maxValue()) >= 0) {
+            if (!isEmptyOrNull(this.get_maxValue()) && Invariant.stringCompare(value, this.get_maxValue()) > 0) {
                 return format(text('Validation.MaxDate'), formatDate(this.get_maxValue(), null));
             }
 


### PR DESCRIPTION
Currently, if we set a max_Date to today then it preventing the today to enter. I mean maxDate itself is considering invalid.
I change the operator '>=' to '>', this will allow the maxValue as valid input.