### PR TITLE
Fix PermissionKeys server typings generation

### DIFF
--- a/src/Serenity.Net.CodeGenerator/CodeGeneration/ServerTypings/ServerTypingsGenerator.PermissionKeys.cs
+++ b/src/Serenity.Net.CodeGenerator/CodeGeneration/ServerTypings/ServerTypingsGenerator.PermissionKeys.cs
@@ -18,9 +18,9 @@ namespace Serenity.CodeGeneration
             GeneratePermissionKeysFor(type, declare: true);
         }
 
-        protected void GeneratePermissionKeysFor(TypeDefinition type, bool declare)
+        protected void GeneratePermissionKeysFor(TypeDefinition type, bool export)
         {
-            cw.Indented(declare ? "declare namespace ": "namespace ");
+            cw.Indented(export ? "export namespace ": "namespace ");
             sb.Append(type.Name);
             cw.InBrace(delegate
             {
@@ -45,7 +45,7 @@ namespace Serenity.CodeGeneration
                         continue;
 
                     sb.AppendLine();
-                    GeneratePermissionKeysFor(nested, declare: false);
+                    GeneratePermissionKeysFor(nested, export: false);
                 }
             });
         }


### PR DESCRIPTION
Hi @volkanceylan,
how are you doing?
Playing with NestedPermissionKeys attribute, I saw that currently the generated TS type is in the following format:

`namespace A.B {
    declare namespace PermissionKeys {
....
    }
}`

which I guess it's incorrect becase it isn't "visible" outside the type itself.
If I'm not wrong the "declare" keyword should be "export" instead:

`namespace A.B {
    export namespace PermissionKeys {
...
    }
}`

See you soon!
Bye