### PR TITLE
Dialect specific SqlQuery.ToString method overriding facility

### DIFF
--- a/src/Serenity.Net.Data/Dialects/ISqlQueryToString.cs
+++ b/src/Serenity.Net.Data/Dialects/ISqlQueryToString.cs
@@ -10,7 +10,7 @@ namespace Serenity.Data
     public interface ISqlQueryToString
     {
         /// <summary>
-        /// The method which will call inside SqlQuery.ToString() method
+        ///    The method which will call inside SqlQuery.ToString() method
         /// </summary>
         /// <returns>
         ///   Formatted SELECT statement</returns>

--- a/src/Serenity.Net.Data/Dialects/ISqlQueryToString.cs
+++ b/src/Serenity.Net.Data/Dialects/ISqlQueryToString.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Serenity.Data
+{
+    /// <summary>
+    /// Abstraction for SQL Query ToString(), e.g. dialect with custom ToString() method.
+    /// </summary>
+    public interface ISqlQueryToString
+    {
+        /// <summary>
+        /// The method which will call inside SqlQuery.ToString() method
+        /// </summary>
+        /// <returns>
+        ///   Formatted SELECT statement</returns>
+        string SqlQueryToString(SqlQuery sqlQuery, SqlQueryElements queryElements);
+    }
+}

--- a/src/Serenity.Net.Data/FluentSql/SqlQueryElements.cs
+++ b/src/Serenity.Net.Data/FluentSql/SqlQueryElements.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Serenity.Data
+{
+    /// <summary>
+    /// SQL query elements which is basically used for generating custor query string outside the SqlQuery class. 
+    /// eg: inside dialect
+    /// </summary>
+    public partial class SqlQueryElements
+    {
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+        public Dictionary<string, string> AliasExpressions { get; set; }
+        public Dictionary<string, IHaveJoins> AliasWithJoins { get; set; }
+        public List<SqlQuery.Column> Columns { get; set; }
+        public bool CountRecords { get; set; }
+        public bool Distinct { get; set; }
+        public StringBuilder From { get; set; }
+        public StringBuilder Having { get; set; }
+        public StringBuilder GroupBy { get; set; }
+        public List<string> OrderBy { get; set; }
+        public string ForXml { get; set; }
+        public string ForJson { get; set; }
+        public int Skip { get; set; }
+        public int Take { get; set; }
+        public StringBuilder Where { get; set; }
+        public int IntoIndex { get; set; } = -1;
+        public List<object> Into { get; set; } = new List<object>();
+        public SqlQuery UnionQuery { get; set; }
+        public SqlUnionType UnionType { get; set; }
+        public QueryWithParams Parent { get; set; }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+
+    }
+}

--- a/src/Serenity.Net.Data/FluentSql/SqlQuery_ToString.cs
+++ b/src/Serenity.Net.Data/FluentSql/SqlQuery_ToString.cs
@@ -12,6 +12,34 @@ namespace Serenity.Data
         ///   Formatted SELECT statement</returns>
         public override string ToString()
         {
+            if (dialect is ISqlQueryToString dialectWithToString)
+            {
+                var queryElements = new SqlQueryElements
+                {
+                    AliasExpressions = aliasExpressions,
+                    AliasWithJoins = aliasWithJoins,
+                    Columns = columns,
+                    CountRecords = countRecords,
+                    Distinct = distinct,
+                    ForJson = forJson,
+                    ForXml = forXml,
+                    From = from,
+                    GroupBy = groupBy,
+                    Having = having,
+                    Into = into,
+                    IntoIndex = intoIndex,
+                    OrderBy = orderBy,
+                    Skip = skip,
+                    Take = take,
+                    UnionQuery = unionQuery,
+                    UnionType = unionType,
+                    Where = where,
+                    Parent = parent
+                };
+
+                return dialectWithToString.SqlQueryToString(this, queryElements);
+            }
+
             var sb = new StringBuilder();
 
             if (unionQuery != null)


### PR DESCRIPTION
added ISqlQueryToString interface to provide a hook for custom query string builder for dialects. eg. Oracle12c etc.

Instead of modifying complex logic inside the SqlQuery.ToString() method this PR will allow writing dialect-specific ToString implementation like the following

```
    public class Oracle12cDialect : OracleDialect, ISqlQueryToString
    {
        public static new readonly ISqlDialect Instance = new Oracle12cDialect();

        public string SqlQueryToString(SqlQuery sqlQuery, SqlQueryElements queryElements)
        {
            throw new NotImplementedException();
        }
    }
```

ref PR https://github.com/serenity-is/Serenity/pull/5250

Please consider this PR because we need a hook to customize the `SqlQuery.ToString` method so that we can handle custom logic eg. database with table partitions etc. 