### PR TITLE
tests and improvements of dialect matching and negating

### DIFF
--- a/src/Serenity.Net.Data/Dialects/ServerType.cs
+++ b/src/Serenity.Net.Data/Dialects/ServerType.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Serenity.Data
+{
+    /// <summary>
+    /// Contains server type names for common dialects
+    /// </summary>
+    public enum ServerType
+    {
+        /// <summary>
+        /// SqlServer
+        /// </summary>
+        SqlServer,
+        /// <summary>
+        /// MySql
+        /// </summary>
+        MySql,
+        /// <summary>
+        /// Sqlite
+        /// </summary>
+        Sqlite,
+        /// <summary>
+        /// Oracle
+        /// </summary>
+        Oracle,
+        /// <summary>
+        /// Firebird
+        /// </summary>
+        Firebird
+    }
+}

--- a/src/Serenity.Net.Data/Mapping/ExpressionAttribute.cs
+++ b/src/Serenity.Net.Data/Mapping/ExpressionAttribute.cs
@@ -19,6 +19,17 @@ namespace Serenity.Data.Mapping
         }
 
         /// <summary>
+        /// Specifies SQL expression and dialects this property corresponds to.
+        /// </summary>
+        /// <param name="value">An SQL expression like (T0.Firstname + ' ' + T0.LastName)</param>
+        /// <param name="serverTypes">Dialects like <see cref="ServerType.MySql" />, <see cref="ServerType.Sqlite" />.</param>
+        public ExpressionAttribute(string value, params ServerType[] serverTypes)
+            : this(value)
+        {
+            Dialect = string.Join(",", serverTypes);
+        }
+
+        /// <summary>
         /// Gets the value.
         /// </summary>
         /// <value>
@@ -33,5 +44,18 @@ namespace Serenity.Data.Mapping
         /// The dialect.
         /// </value>
         public string Dialect { get; set; }
+
+        /// <summary>
+        /// Gets or sets the negating of the dialect.
+        /// </summary>
+        /// <value>
+        /// The negating of the dialect.
+        /// </value>
+        public bool NegateDialect
+        {
+            get => Dialect != null && Dialect.StartsWith('!');
+            set => Dialect = value ? (!NegateDialect ? ("!" + Dialect) : Dialect) :
+                (NegateDialect ?  Dialect[1..] : Dialect);
+        }
     }
 }

--- a/src/Serenity.Net.Data/Mapping/InnerJoinAttribute.cs
+++ b/src/Serenity.Net.Data/Mapping/InnerJoinAttribute.cs
@@ -34,6 +34,31 @@ namespace Serenity.Data.Mapping
         }
 
         /// <summary>
+        /// Adds a inner join on foreign key. Use this version only on properties with ForeignKey attribute.
+        /// </summary>
+        /// <param name="alias">Foreign join alias</param>
+        /// <param name="serverTypes">Dialects like <see cref="ServerType.MySql" />, <see cref="ServerType.Sqlite" />.</param>
+        public InnerJoinAttribute(string alias, params ServerType[] serverTypes)
+            : this(alias)
+        {
+            Dialect = string.Join(",", serverTypes);
+        }
+
+        /// <summary>
+        /// Adds a inner join
+        /// </summary>
+        /// <param name="alias">Join alias</param>
+        /// <param name="toTable">Join table</param>
+        /// <param name="onCriteria">If the attribute is used on a property, this parameter is a field name, if used on a class,
+        /// this parameter is the ON criteria of the inner join statement.</param>
+        /// <param name="serverTypes">Dialects like <see cref="ServerType.MySql" />, <see cref="ServerType.Sqlite" />.</param>
+        public InnerJoinAttribute(string alias, string toTable, string onCriteria, params ServerType[] serverTypes)
+            : this(alias, toTable, onCriteria)
+        {
+            Dialect = string.Join(",", serverTypes);
+        }
+
+        /// <summary>
         /// Gets the alias.
         /// </summary>
         /// <value>
@@ -88,5 +113,18 @@ namespace Serenity.Data.Mapping
         /// The dialect.
         /// </value>
         public string Dialect { get; set; }
+
+        /// <summary>
+        /// Gets or sets the negating of the dialect.
+        /// </summary>
+        /// <value>
+        /// The negating of the dialect.
+        /// </value>
+        public bool NegateDialect
+        {
+            get => Dialect != null && Dialect.StartsWith('!');
+            set => Dialect = value ? (!NegateDialect ? ("!" + Dialect) : Dialect) :
+                (NegateDialect ? Dialect[1..] : Dialect);
+        }
     }
 }

--- a/src/Serenity.Net.Data/Mapping/LeftJoinAttribute.cs
+++ b/src/Serenity.Net.Data/Mapping/LeftJoinAttribute.cs
@@ -34,6 +34,31 @@ namespace Serenity.Data.Mapping
         }
 
         /// <summary>
+        /// Adds a left join on foreign key. Use this version only on properties with ForeignKey attribute.
+        /// </summary>
+        /// <param name="alias">Foreign join alias</param>
+        /// <param name="serverTypes">Dialects like <see cref="ServerType.MySql" />, <see cref="ServerType.Sqlite" />.</param>
+        public LeftJoinAttribute(string alias, params ServerType[] serverTypes)
+            : this(alias)
+        {
+            Dialect = string.Join(",", serverTypes);
+        }
+
+        /// <summary>
+        /// Adds a left join
+        /// </summary>
+        /// <param name="alias">Join alias</param>
+        /// <param name="toTable">Join table</param>
+        /// <param name="onCriteria">If the attribute is used on a property, this parameter is a field name, if used on a class,
+        /// this parameter is the ON criteria of the left join statement.</param>
+        /// <param name="serverTypes">Dialects like <see cref="ServerType.MySql" />, <see cref="ServerType.Sqlite" />.</param>
+        public LeftJoinAttribute(string alias, string toTable, string onCriteria, params ServerType[] serverTypes)
+            : this(alias, toTable, onCriteria)
+        {
+            Dialect = string.Join(",", serverTypes);
+        }
+
+        /// <summary>
         /// Gets the alias.
         /// </summary>
         /// <value>
@@ -88,5 +113,18 @@ namespace Serenity.Data.Mapping
         /// The dialect.
         /// </value>
         public string Dialect { get; set; }
+
+        /// <summary>
+        /// Gets or sets the negating of the dialect.
+        /// </summary>
+        /// <value>
+        /// The negating of the dialect.
+        /// </value>
+        public bool NegateDialect
+        {
+            get => Dialect != null && Dialect.StartsWith('!');
+            set => Dialect = value ? (!NegateDialect ? ("!" + Dialect) : Dialect) :
+                (NegateDialect ? Dialect[1..] : Dialect);
+        }
     }
 }

--- a/src/Serenity.Net.Data/Mapping/OuterApplyAttribute.cs
+++ b/src/Serenity.Net.Data/Mapping/OuterApplyAttribute.cs
@@ -22,6 +22,18 @@ namespace Serenity.Data.Mapping
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="OuterApplyAttribute"/> class.
+        /// </summary>
+        /// <param name="alias">The alias.</param>
+        /// <param name="innerQuery">The inner query.</param>
+        /// <param name="serverTypes">Dialects like <see cref="ServerType.MySql" />, <see cref="ServerType.Sqlite" />.</param>
+        public OuterApplyAttribute(string alias, string innerQuery, params ServerType[] serverTypes)
+            : this(alias, innerQuery)
+        {
+            Dialect = string.Join(",", serverTypes);
+        }
+
+        /// <summary>
         /// Gets the alias.
         /// </summary>
         /// <value>
@@ -71,5 +83,18 @@ namespace Serenity.Data.Mapping
         /// The dialect.
         /// </value>
         public string Dialect { get; set; }
+
+        /// <summary>
+        /// Gets or sets the negating of the dialect.
+        /// </summary>
+        /// <value>
+        /// The negating of the dialect.
+        /// </value>
+        public bool NegateDialect
+        {
+            get => Dialect != null && Dialect.StartsWith('!');
+            set => Dialect = value ? (!NegateDialect ? ("!" + Dialect) : Dialect) :
+                (NegateDialect ? Dialect[1..] : Dialect);
+        }
     }
 }

--- a/tests/Serenity.Net.Entity.Tests/Row/RowDialectExpressionTests.cs
+++ b/tests/Serenity.Net.Entity.Tests/Row/RowDialectExpressionTests.cs
@@ -1,0 +1,220 @@
+using Serenity.Data;
+using Serenity.Data.Mapping;
+using Serenity.Tests.Entities;
+using System;
+using System.Reflection;
+using Xunit;
+
+namespace Serenity.Tests.Entity
+{
+    public class RowDialectExpressionTests
+    {
+        #region Rows used in tests
+        [LeftJoin("a", "x", "y")]
+        [LeftJoin("a", "z", "w")]
+        public class DuplicateLeftJoinNoDialectRow : Row<DuplicateLeftJoinNoDialectRow.RowFields>
+        {
+            public class RowFields : RowFieldsBase
+            {
+            }
+        }
+
+        [LeftJoin("a", "x", "y", ServerType.MySql)]
+        [LeftJoin("a", "z", "w", ServerType.SqlServer)]
+        [LeftJoin("b", "y", "z", ServerType.MySql, NegateDialect = true)]
+        [LeftJoin("b", "w", "y", ServerType.SqlServer, NegateDialect = true)]
+        [InnerJoin("inner", "a", "b", ServerType.MySql)]
+        [InnerJoin("inner", "b", "b", ServerType.SqlServer)]
+        [InnerJoin("inner negate", "y", "z", ServerType.MySql, NegateDialect = true)]
+        [InnerJoin("inner negate", "w", "y", ServerType.SqlServer, NegateDialect = true)]
+        [OuterApply("outer", "y", ServerType.MySql)]
+        [OuterApply("outer", "w", ServerType.SqlServer)]
+        [OuterApply("outer negate", "y", ServerType.MySql, NegateDialect = true)]
+        [OuterApply("outer negate", "w", ServerType.SqlServer, NegateDialect = true)]
+        public class DuplicateLeftJoinDifferentDialectWithForeignKeyLeftJoinRow : Row<DuplicateLeftJoinDifferentDialectWithForeignKeyLeftJoinRow.RowFields>
+        {
+            [ForeignKey("a", "x"), LeftJoin("y", ServerType.Sqlite), LeftJoin("z", ServerType.SqlServer)]
+            [LeftJoin("q", "w", "x", ServerType.MySql, NegateDialect = true), LeftJoin("q", "z", "y", ServerType.SqlServer, NegateDialect = true)]
+            [InnerJoin("e", "w", "x", ServerType.MySql), InnerJoin("e", "z", "y", ServerType.SqlServer)]
+            [InnerJoin("w", "w", "x", ServerType.MySql, NegateDialect = true), InnerJoin("w", "z", "y", ServerType.SqlServer, NegateDialect = true)]
+            public int? Test
+            {
+                get => fields.Test[this];
+                set => fields.Test[this] = value;
+            }
+
+            public class RowFields : RowFieldsBase
+            {
+                public Int32Field Test;
+            }
+        }
+
+
+        #endregion
+
+        [Fact]
+        public void Raises_Exception_If_Join_Is_Ambiguous()
+        {
+            var ex = Assert.Throws<AmbiguousMatchException>(() =>
+            {
+                new DuplicateLeftJoinNoDialectRow.RowFields().Initialize(null, SqlServer2012Dialect.Instance);
+            });
+
+            Assert.Contains(nameof(DuplicateLeftJoinNoDialectRow), ex.Message);
+            Assert.Contains("'a'", ex.Message);
+        }
+
+        [Fact]
+        public void Uses_One_Of_LeftJoins_If_Dialect_For_Same_Alias_Joins_Are_Different()
+        {
+            var fields = new DuplicateLeftJoinDifferentDialectWithForeignKeyLeftJoinRow.RowFields();
+            fields.Initialize(null, SqlServer2012Dialect.Instance);
+
+            var join = Assert.Contains("a", fields.Joins);
+            Assert.Equal("z", join.Table);
+            Assert.Equal("w", join.OnCriteria?.ToString());
+        }
+
+        [Fact]
+        public void Should_Use_Sqlite_Dialect_On_ForeignKey_LeftJoin()
+        {
+            var fields = new DuplicateLeftJoinDifferentDialectWithForeignKeyLeftJoinRow.RowFields();
+            fields.Initialize(null, SqliteDialect.Instance);
+
+            var join = Assert.Contains("y", fields.Joins);
+            Assert.Equal("a", join.Table);
+            Assert.Equal("(y.x = T0.Test)", join.OnCriteria?.ToString());
+        }
+
+        [Fact]
+        public void Should_Use_SqlServer_Dialect_On_ForeignKey_LeftJoin()
+        {
+            var fields = new DuplicateLeftJoinDifferentDialectWithForeignKeyLeftJoinRow.RowFields();
+            fields.Initialize(null, SqlServer2012Dialect.Instance);
+
+            var join = Assert.Contains("z", fields.Joins);
+            Assert.Equal("a", join.Table);
+            Assert.Equal("(z.x = T0.Test)", join.OnCriteria?.ToString());
+        }
+
+        [Fact]
+        public void Uses_Matching_Dialect_LeftJoin_On_Property()
+        {
+            var fields = new DuplicateLeftJoinDifferentDialectWithForeignKeyLeftJoinRow.RowFields();
+            fields.Initialize(null, SqliteDialect.Instance);
+
+            var join = Assert.Contains("y", fields.Joins);
+            Assert.Equal("a", join.Table);
+            Assert.Equal("(y.x = T0.Test)", join.OnCriteria?.ToString());
+        }
+
+        [Fact]
+        public void Can_Negate_Matching_Dialect_On_SqlServer_LeftJoin()
+        {
+            var fields = new DuplicateLeftJoinDifferentDialectWithForeignKeyLeftJoinRow.RowFields();
+            fields.Initialize(null, SqlServer2012Dialect.Instance);
+
+            var join = Assert.Contains("b", fields.Joins);
+            Assert.Equal("y", join.Table);
+            Assert.Equal("z", join.OnCriteria?.ToString());
+        }
+
+        [Fact]
+        public void Can_Negate_Matching_Dialect_On_MySql_LeftJoin()
+        {
+            var fields = new DuplicateLeftJoinDifferentDialectWithForeignKeyLeftJoinRow.RowFields();
+            fields.Initialize(null, MySqlDialect.Instance);
+
+            var join = Assert.Contains("b", fields.Joins);
+            Assert.Equal("w", join.Table);
+            Assert.Equal("y", join.OnCriteria?.ToString());
+        }
+
+        [Fact]
+        public void Can_Negate_Matching_Dialect_On_SqlServer_LeftJoin_On_Property()
+        {
+            var fields = new DuplicateLeftJoinDifferentDialectWithForeignKeyLeftJoinRow.RowFields();
+            fields.Initialize(null, SqlServer2012Dialect.Instance);
+
+            var join = Assert.Contains("q", fields.Joins);
+            Assert.Equal("w", join.Table);
+            Assert.Equal("(q.x = T0.Test)", join.OnCriteria?.ToString());
+        }
+
+        [Fact]
+        public void Can_Negate_Matching_Dialect_On_MySql_LeftJoin_On_Property()
+        {
+            var fields = new DuplicateLeftJoinDifferentDialectWithForeignKeyLeftJoinRow.RowFields();
+            fields.Initialize(null, MySqlDialect.Instance);
+
+            var join = Assert.Contains("q", fields.Joins);
+            Assert.Equal("z", join.Table);
+            Assert.Equal("(q.y = T0.Test)", join.OnCriteria?.ToString());
+        }
+
+        [Fact]
+        public void Uses_One_Of_InnerJoins_If_Dialect_For_Same_Alias_Joins_Are_Different()
+        {
+            var fields = new DuplicateLeftJoinDifferentDialectWithForeignKeyLeftJoinRow.RowFields();
+            fields.Initialize(null, SqlServer2012Dialect.Instance);
+
+            var join = Assert.Contains("inner", fields.Joins);
+            Assert.Equal("b", join.Table);
+            Assert.Equal("b", join.OnCriteria?.ToString());
+        }
+
+        [Fact]
+        public void Uses_One_Of_OuterApplys_If_Dialect_For_Same_Alias_Joins_Are_Different()
+        {
+            var fields = new DuplicateLeftJoinDifferentDialectWithForeignKeyLeftJoinRow.RowFields();
+            fields.Initialize(null, SqlServer2012Dialect.Instance);
+
+            var join = Assert.Contains("outer", fields.Joins);
+            Assert.Equal("(w)", join.Table);
+        }
+
+        [Fact]
+        public void Can_Negate_One_Of_InnerJoins_If_Dialect_For_Same_Alias_Joins_Are_Different()
+        {
+            var fields = new DuplicateLeftJoinDifferentDialectWithForeignKeyLeftJoinRow.RowFields();
+            fields.Initialize(null, SqlServer2012Dialect.Instance);
+
+            var join = Assert.Contains("inner negate", fields.Joins);
+            Assert.Equal("y", join.Table);
+            Assert.Equal("z", join.OnCriteria?.ToString());
+        }
+
+        [Fact]
+        public void Can_Negate_One_Of_OuterApplys_If_Dialect_For_Same_Alias_Joins_Are_Different()
+        {
+            var fields = new DuplicateLeftJoinDifferentDialectWithForeignKeyLeftJoinRow.RowFields();
+            fields.Initialize(null, SqlServer2012Dialect.Instance);
+
+            var join = Assert.Contains("outer negate", fields.Joins);
+            Assert.Equal("(y)", join.Table);
+        }
+
+
+        [Fact]
+        public void Uses_One_Of_InnerJoins_If_Dialect_For_Same_Alias_Joins_Are_Different_On_Property()
+        {
+            var fields = new DuplicateLeftJoinDifferentDialectWithForeignKeyLeftJoinRow.RowFields();
+            fields.Initialize(null, SqlServer2012Dialect.Instance);
+
+            var join = Assert.Contains("e", fields.Joins);
+            Assert.Equal("z", join.Table);
+            Assert.Equal("(e.y = T0.Test)", join.OnCriteria?.ToString());
+        }
+
+        [Fact]
+        public void Can_Negate_One_Of_InnerJoins_If_Dialect_For_Same_Alias_Joins_Are_Different_On_Property()
+        {
+            var fields = new DuplicateLeftJoinDifferentDialectWithForeignKeyLeftJoinRow.RowFields();
+            fields.Initialize(null, SqlServer2012Dialect.Instance);
+
+            var join = Assert.Contains("w", fields.Joins);
+            Assert.Equal("w", join.Table);
+            Assert.Equal("(w.x = T0.Test)", join.OnCriteria?.ToString());
+        }
+    }
+}


### PR DESCRIPTION
added ServerType enum to support intellisense on dialects
made OuterApplyAttribute, LeftJoinAttribute, InnerJoinAttribute, and ExpressionAttribute accept ServerType  to set their Dialect
added NegateDialect property to the said properties

added tests for the new dialect matching and negating