### PR TITLE
made AutoParam consistent after cloning SqlQuery

### DIFF
--- a/src/Serenity.Net.Data/FluentSql/SqlQuery_Clone.cs
+++ b/src/Serenity.Net.Data/FluentSql/SqlQuery_Clone.cs
@@ -30,7 +30,8 @@ namespace Serenity.Data
                 forXml = forXml,
                 forJson = forJson,
                 unionQuery = unionQuery,
-                unionType = unionType
+                unionType = unionType,
+                nextAutoParam = nextAutoParam
             };
 
             Column s;

--- a/src/Serenity.Net.Data/QueryModel/QueryWithParams.cs
+++ b/src/Serenity.Net.Data/QueryModel/QueryWithParams.cs
@@ -31,6 +31,8 @@ namespace Serenity.Data
         /// </summary>
         protected Dictionary parameters;
 
+        protected int nextAutoParam;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="QueryWithParams"/> class.
         /// </summary>
@@ -138,7 +140,7 @@ namespace Serenity.Data
             if (parent != null)
                 return parent.AutoParam();
 
-            return new Parameter((ParamCount + 1).IndexParam());
+            return new Parameter((++nextAutoParam).IndexParam());
         }
 
         /// <summary>

--- a/src/Serenity.Net.Data/QueryModel/QueryWithParams.cs
+++ b/src/Serenity.Net.Data/QueryModel/QueryWithParams.cs
@@ -31,8 +31,6 @@ namespace Serenity.Data
         /// </summary>
         protected Dictionary parameters;
 
-        private int nextAutoParam;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="QueryWithParams"/> class.
         /// </summary>
@@ -140,7 +138,7 @@ namespace Serenity.Data
             if (parent != null)
                 return parent.AutoParam();
 
-            return new Parameter((++nextAutoParam).IndexParam());
+            return new Parameter((ParamCount + 1).IndexParam());
         }
 
         /// <summary>


### PR DESCRIPTION
consider the following query

```
            var query = new SqlQuery()
                .From(fld)
                .Select(Sql.Count())
                .Where(fld.BirthDate > DateTime.Today.AddYears(18));

```
the for some reason we need to clone the query and add another `where` condition

```
var query2 = query.Clone()
                     .Where(cfld.SomeField == 0);
```
but the query2 throws the following exception :
`An item with the same key has already been added. Key: @p1`

The issue is the private variable `nextAutoParam` which is not cloned. Thus its value always reset to 0 after cloning.

To fixed this issue I have created this PR.