### PR TITLE
Permission tests for ListRequestHandler, CriteriaFieldExpressionReplacer, ServiceAuthorizeAttribute

### DIFF
--- a/src/Serenity.Net.Web/Mvc/ServiceAuthorizeAttribute.cs
+++ b/src/Serenity.Net.Web/Mvc/ServiceAuthorizeAttribute.cs
@@ -35,7 +35,7 @@ namespace Serenity.Services
 
             var localizer = context.HttpContext.RequestServices.GetRequiredService<ITextLocalizer>();
 
-            if (!context.HttpContext.User.IsLoggedIn())
+            if (context.HttpContext.User.IsLoggedIn())
             {
                 context.Result = new Result<ServiceResponse>(new ServiceResponse
                 {

--- a/tests/Serenity.Net.Services.Tests/RequestHandlers/Helpers/CriteriaFieldExpressionReplacer/CriteriaFieldExpressionReplacerTests.Permission.cs
+++ b/tests/Serenity.Net.Services.Tests/RequestHandlers/Helpers/CriteriaFieldExpressionReplacer/CriteriaFieldExpressionReplacerTests.Permission.cs
@@ -1,0 +1,81 @@
+﻿using Serenity.Data;
+using Serenity.Services;
+using Xunit;
+
+namespace Serenity.Tests.Services
+{
+    public partial class CriteriaFieldExpressionReplacerTests
+    {
+        [Fact]
+        public void Throws_If_Field_Has_DenyFiltering_Flag()
+        {
+            var mockPermissions = new MockPermissions(perm => false);
+            var replacer = new CriteriaFieldExpressionReplacer(new TestRow(), mockPermissions, false);
+
+            Assert.Throws<ValidationError>(() => replacer.Validate(new Criteria(TestRow.Fields.DenyFilteringField.PropertyName)));
+        }
+
+        [Fact]
+        public void Throws_If_Field_Has_NotMapped_Flag()
+        {
+            var mockPermissions = new MockPermissions(perm => false);
+            var replacer = new CriteriaFieldExpressionReplacer(new TestRow(), mockPermissions, false);
+
+            Assert.Throws<ValidationError>(() => replacer.Validate(new Criteria(TestRow.Fields.NotMappedField.PropertyName)));
+        }
+
+        [Fact]
+        public void Throws_If_Field_Has_MinSelectLevel_Of_Never()
+        {
+            var mockPermissions = new MockPermissions(perm => false);
+            var replacer = new CriteriaFieldExpressionReplacer(new TestRow(), mockPermissions, false);
+
+            Assert.Throws<ValidationError>(() => replacer.Validate(new Criteria(TestRow.Fields.MinSelectLevelNeverField.PropertyName)));
+        }
+
+        [Fact]
+        public void Throws_If_Field_ReadPermission_And_User_Doesnt_Have_Permission()
+        {
+            var mockPermissions = new MockPermissions(perm => false);
+            var replacer = new CriteriaFieldExpressionReplacer(new TestRow(), mockPermissions, false);
+
+            Assert.Throws<ValidationError>(() => replacer.Validate(new Criteria(TestRow.Fields.ExtraReadPermissionField.PropertyName)));
+        }
+
+        [Fact]
+        public void Throws_If_Field_Is_Not_A_Lookup_Permission_And_Lookup_Mode_Is_True()
+        {
+            var mockPermissions = new MockPermissions(perm => false);
+            var replacer = new CriteriaFieldExpressionReplacer(new TestRow(), mockPermissions, true);
+
+            Assert.Throws<ValidationError>(() => replacer.Validate(new Criteria(TestRow.Fields.NormalField.PropertyName)));
+        }
+
+        [Fact]
+        public void Throws_If_Field_Is_A_Lookup_Permission_And_Lookup_Mode_Is_True_And_User_Doesnt_Have_Fields_Permission()
+        {
+            var mockPermissions = new MockPermissions(perm => false);
+            var replacer = new CriteriaFieldExpressionReplacer(new TestRow(), mockPermissions, true);
+
+            Assert.Throws<ValidationError>(() => replacer.Validate(new Criteria(TestRow.Fields.ExtraReadPermissionWithLookupIncludeField.PropertyName)));
+        }
+
+        [Fact]
+        public void Allows_If_Field_Is_A_Normal_Field_And_User_Have_Fields_Permission()
+        {
+            var mockPermissions = new MockPermissions(perm => perm == ReadPermission);
+            var replacer = new CriteriaFieldExpressionReplacer(new TestRow(), mockPermissions, false);
+
+            replacer.Validate(new Criteria(TestRow.Fields.NormalField.PropertyName));
+        }
+
+        [Fact]
+        public void Allows_If_Field_Has_ReadPermission_And_User_Also_Have_That_Permission()
+        {
+            var mockPermissions = new MockPermissions(perm => perm is ReadPermission or ExtraReadPermission);
+            var replacer = new CriteriaFieldExpressionReplacer(new TestRow(), mockPermissions, false);
+
+            replacer.Validate(new Criteria(TestRow.Fields.ExtraReadPermissionField.PropertyName));
+        }
+    }
+}

--- a/tests/Serenity.Net.Services.Tests/RequestHandlers/Helpers/CriteriaFieldExpressionReplacer/CriteriaFieldExpressionReplacerTests.TestRow.cs
+++ b/tests/Serenity.Net.Services.Tests/RequestHandlers/Helpers/CriteriaFieldExpressionReplacer/CriteriaFieldExpressionReplacerTests.TestRow.cs
@@ -1,0 +1,93 @@
+﻿using Serenity.Data;
+using Serenity.Data.Mapping;
+
+namespace Serenity.Tests.Services;
+
+public partial class CriteriaFieldExpressionReplacerTests
+{
+    private const string ReadPermission = "Test:ReadPermission";
+    private const string ServiceLookupPermission = "TestService:LookupPermission";
+    private const string ExtraReadPermission = "Test:ExtraSpecialField";
+    
+    [ReadPermission(ReadPermission)]
+    [ServiceLookupPermission(ServiceLookupPermission)]
+    private class TestRow : Row<TestRow.RowFields>, IIdRow
+    {
+        [IdProperty]
+        public int? Id
+        {
+            get => fields.Id[this];
+            set => fields.Id[this] = value;
+        }
+
+        [NameProperty]
+        public string Name
+        {
+            get => fields.Name[this];
+            set => fields.Name[this] = value;
+        }
+
+        [LookupInclude]
+        public string LookupIncludeField
+        {
+            get => fields.LookupIncludeField[this];
+            set => fields.LookupIncludeField[this] = value;
+        }
+
+        public string NormalField
+        {
+            get => fields.NormalField[this];
+            set => fields.NormalField[this] = value;
+        }
+        
+        [ReadPermission(ExtraReadPermission)]
+        public string ExtraReadPermissionField
+        {
+            get => fields.ExtraReadPermissionField[this];
+            set => fields.ExtraReadPermissionField[this] = value;
+        }
+        
+        [ReadPermission(ExtraReadPermission), LookupInclude]
+        public string ExtraReadPermissionWithLookupIncludeField
+        {
+            get => fields.ExtraReadPermissionWithLookupIncludeField[this];
+            set => fields.ExtraReadPermissionWithLookupIncludeField[this] = value;
+        }
+        
+        [SetFieldFlags(FieldFlags.DenyFiltering)]
+        public string DenyFilteringField
+        {
+            get => fields.DenyFilteringField[this];
+            set => fields.DenyFilteringField[this] = value;
+        }
+
+        [NotMapped]
+        public string NotMappedField
+        {
+            get => fields.NotMappedField[this];
+            set => fields.NotMappedField[this] = value;
+        }
+        
+        [MinSelectLevel(SelectLevel.Never)]
+        public string MinSelectLevelNeverField
+        {
+            get => fields.MinSelectLevelNeverField[this];
+            set => fields.MinSelectLevelNeverField[this] = value;
+        }
+
+        public class RowFields : RowFieldsBase
+        {
+#pragma warning disable CS0649
+            public Int32Field Id;
+            public StringField Name;
+            public StringField LookupIncludeField;
+            public StringField NormalField;
+            public StringField ExtraReadPermissionField;
+            public StringField ExtraReadPermissionWithLookupIncludeField;
+            public StringField DenyFilteringField;
+            public StringField NotMappedField;
+            public StringField MinSelectLevelNeverField;
+#pragma warning restore CS0649
+        }
+    }
+}

--- a/tests/Serenity.Net.Services.Tests/RequestHandlers/List/ListRequestHandlerTests.Permissions.cs
+++ b/tests/Serenity.Net.Services.Tests/RequestHandlers/List/ListRequestHandlerTests.Permissions.cs
@@ -1,0 +1,112 @@
+﻿using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using Serenity.Services;
+using Xunit;
+
+namespace Serenity.Tests.Services;
+
+public partial class ListRequestHandlerTests
+{
+    [Fact]
+    public void Throws_If_User_Doesnt_Have_Permissions()
+    {
+        var context = new NullRequestContext().WithPermissions(x => x is not ReadPermission and not ServiceLookupPermission);
+        var handler = new ListRequestHandler<TestRow>(context);
+        Assert.Throws<ValidationError>(() => handler.List(new MockDbConnection(), new()));
+    }
+
+    [Fact]
+    public void Passes_If_User_Has_ReadPermission()
+    {
+        var context = new NullRequestContext().WithPermissions(x => x is ReadPermission);
+        var handler = new ListRequestHandler<TestRow>(context);
+        handler.List(new MockDbConnection(), new());
+    }
+
+    [Fact]
+    public void Passes_If_User_Has_ServiceLookupPermission()
+    {
+        var context = new NullRequestContext().WithPermissions(x => x is ServiceLookupPermission);
+        var handler = new ListRequestHandler<TestRow>(context);
+        handler.List(new MockDbConnection(), new());
+    }
+
+    [Fact]
+    public void Should_Select_All_Fields_If_User_Has_Permissions()
+    {
+        var context = new NullRequestContext().WithPermissions(x => x is ReadPermission or ExtraSpecialFieldPermission);
+        var handler = new ListRequestHandler<TestRow>(context);
+
+        handler.List(NewMockDbConnectionTestSelectedFields(TestRow.Fields.Select(x => x.Name)), new());
+    }
+
+    [Fact]
+    public void Should_Not_Select_A_Field_If_User_Doesnt_Have_Permission_For_That_Field()
+    {
+        var context = new NullRequestContext().WithPermissions(x => x is ReadPermission);
+        var handler = new ListRequestHandler<TestRow>(context);
+
+        handler.List(NewMockDbConnectionTestSelectedFields(
+            TestRow.Fields.Select(x => x.Name).Where(x => x != TestRow.Fields.ExtraSpecialField.Name)
+        ), new());
+    }
+
+    [Fact]
+    public void Should_Not_Select_A_Field_If_User_Doesnt_Have_Permission_For_That_Field_Even_If_Field_Is_In_IncludeColumns()
+    {
+        var context = new NullRequestContext().WithPermissions(x => x is ReadPermission);
+        var handler = new ListRequestHandler<TestRow>(context);
+
+        handler.List(NewMockDbConnectionTestSelectedFields(
+            TestRow.Fields.Select(x => x.Name).Where(x => x != TestRow.Fields.ExtraSpecialField.Name)
+        ), new()
+        {
+            IncludeColumns = new() {TestRow.Fields.ExtraSpecialField.Name}
+        });
+    }
+    
+    [Fact]
+    public void Should_Not_Select_A_Field_If_User_Doesnt_Have_Permission_For_That_Field_Even_If_Field_Is_In_IncludeColumns_On_Fields_With_ReadPermission()
+    {
+        var context = new NullRequestContext().WithPermissions(x => x is ServiceLookupPermission);
+        var handler = new ListRequestHandler<TestRow>(context);
+
+        handler.List(NewMockDbConnectionTestSelectedFields(
+            TestRow.Fields.Where(x => x.IsLookup).Select(x => x.Name)
+        ), new()
+        {
+            IncludeColumns = new() {TestRow.Fields.NormalField.Name}
+        });
+    }
+
+    [Fact]
+    public void Should_Throw_When_Request_Doesnt_Have_Any_Permissions()
+    {
+        var context = new NullRequestContext();
+        var handler = new ListRequestHandler<TestRow>(context);
+        
+        Assert.Throws<ValidationError>(() => handler.List(new NullDbConnection(), new()));
+    }
+
+    private static IDbConnection NewMockDbConnectionTestSelectedFields(IEnumerable<string> containsFields)
+    {
+        var db = new MockDbConnection();
+        db.OnExecuteReader(command =>
+        {
+            var enumerable = containsFields as string[] ?? containsFields.ToArray();
+
+            foreach (var field in TestRow.Fields)
+            {
+                if (enumerable.Contains(field.Name))
+                    Assert.Contains("T0." + field.Name, command.CommandText);
+                else
+                    Assert.DoesNotContain("T0." + field.Name, command.CommandText);
+            }
+
+            return new MockDataReader();
+        });
+
+        return db;
+    }
+}

--- a/tests/Serenity.Net.Services.Tests/RequestHandlers/List/ListRequestHandlerTests.TestRow.cs
+++ b/tests/Serenity.Net.Services.Tests/RequestHandlers/List/ListRequestHandlerTests.TestRow.cs
@@ -1,0 +1,61 @@
+﻿using Serenity.Data;
+using Serenity.Data.Mapping;
+
+namespace Serenity.Tests.Services;
+
+public partial class ListRequestHandlerTests
+{
+    private const string ReadPermission = "Test:ReadPermission";
+    private const string ServiceLookupPermission = "TestService:LookupPermission";
+    private const string ExtraSpecialFieldPermission = "Test:ExtraSpecialField";
+    
+    [ReadPermission(ReadPermission)]
+    [ServiceLookupPermission(ServiceLookupPermission)]
+    private class TestRow : Row<TestRow.RowFields>, IIdRow
+    {
+        [IdProperty]
+        public int? Id
+        {
+            get => fields.Id[this];
+            set => fields.Id[this] = value;
+        }
+
+        [NameProperty]
+        public string Name
+        {
+            get => fields.Name[this];
+            set => fields.Name[this] = value;
+        }
+
+        [LookupInclude]
+        public string LookupIncludeField
+        {
+            get => fields.LookupIncludeField[this];
+            set => fields.LookupIncludeField[this] = value;
+        }
+
+        public string NormalField
+        {
+            get => fields.NormalField[this];
+            set => fields.NormalField[this] = value;
+        }
+        
+        [ReadPermission(ExtraSpecialFieldPermission)]
+        public string ExtraSpecialField
+        {
+            get => fields.ExtraSpecialField[this];
+            set => fields.ExtraSpecialField[this] = value;
+        }
+
+        public class RowFields : RowFieldsBase
+        {
+#pragma warning disable CS0649
+            public Int32Field Id;
+            public StringField Name;
+            public StringField LookupIncludeField;
+            public StringField NormalField;
+            public StringField ExtraSpecialField;
+#pragma warning restore CS0649
+        }
+    }
+}

--- a/tests/Serenity.Net.Web.Tests/Mocks/MockTextLocalizer.cs
+++ b/tests/Serenity.Net.Web.Tests/Mocks/MockTextLocalizer.cs
@@ -1,0 +1,7 @@
+﻿namespace Serenity.Tests
+{
+    public class MockTextLocalizer : ITextLocalizer
+    {
+        public string TryGet(string key) => key;
+    }
+}

--- a/tests/Serenity.Net.Web.Tests/Mvc/ServiceAuthorizeAttributeTests.cs
+++ b/tests/Serenity.Net.Web.Tests/Mvc/ServiceAuthorizeAttributeTests.cs
@@ -1,0 +1,298 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Serenity.Abstractions;
+using Serenity.Data;
+using Serenity.Services;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Security.Claims;
+using Xunit;
+
+namespace Serenity.Tests.Web.Mvc
+{
+    public class ServiceAuthorizeAttributeTests
+    {
+        private const string NotLoggedInErrorCode = "NotLoggedIn";
+        private const string AccessDeniedErrorCode = "AccessDenied";
+
+        [Fact]
+        public void Passes_If_Permission_Is_Null_And_Context_Is_Logged_In()
+        {
+            var sutResult = TestResourceFilters(new IResourceFilter[]
+                {
+                    new ServiceAuthorizeAttribute((string) null)
+                },
+                isLoggedIn: true);
+
+            Assert.Null(sutResult);
+        }
+
+        [Fact]
+        public void Passes_If_Permission_Is_Not_Null_And_Context_Has_That_Permission()
+        {
+            var sutResult = TestResourceFilters(new IResourceFilter[]
+                {
+                    new ServiceAuthorizeAttribute("Test:Permission")
+                },
+                permissions: new[] {"Test:Permission"});
+
+            Assert.Null(sutResult);
+        }
+
+        [Fact]
+        public void Passes_If_OrPermission_Is_Not_Null_And_Context_Has_That_Permission()
+        {
+            var sutResult = TestResourceFilters(new IResourceFilter[]
+                {
+                    new OrPermissionSetAttribute("Test:DoesntHave", "Test:Permission")
+                },
+                permissions: new[] {"Test:Permission"});
+
+            Assert.Null(sutResult);
+        }
+
+        [Fact]
+        public void Passes_If_There_Is_Any_ServiceAuthorizeAttribute_With_Override_True_After_This()
+        {
+            var sutResult = TestResourceFilters(new IResourceFilter[]
+                {
+                    new ServiceAuthorizeAttribute("Test:DoesntHave"),
+                    new ServiceAuthorizeAttribute("Test:Permission")
+                },
+                permissions: new[] {"Test:Permission"});
+
+            Assert.Null(sutResult);
+        }
+
+        [Fact]
+        public void Passes_If_There_Is_Any_ServiceAuthorizeAttribute_With_Or_Permission_And_Override_True_After_This()
+        {
+            var sutResult = TestResourceFilters(new IResourceFilter[]
+                {
+                    new ServiceAuthorizeAttribute("Test:DoesntHave"),
+                    new OrPermissionSetAttribute("Test:DoesntHave2", "Test:Permission")
+                },
+                permissions: new[] {"Test:Permission"});
+
+            Assert.Null(sutResult);
+        }
+
+        [Fact]
+        public void Fails_If_There_Is_Any_ServiceAuthorizeAttribute_With_Override_False_After_This()
+        {
+            var sutResult = TestResourceFilters(new IResourceFilter[]
+                {
+                    new ServiceAuthorizeAttribute("Test:DoesntHave"),
+                    new OrPermissionSetAttribute("Test:DoesntHave2", "Test:Permission", setOverride: false)
+                },
+                permissions: new[] {"Test:Permission"});
+
+            Assert.Equal(AccessDeniedErrorCode, sutResult.Error.Code);
+        }
+
+        [Fact]
+        public void Fails_If_Users_Have_No_Permission_Even_On_Overrides()
+        {
+            var sutResult = TestResourceFilters(new IResourceFilter[]
+            {
+                new OrPermissionSetAttribute("Test:DoesntHave2", "Test:DoesntHave3"),
+                new ServiceAuthorizeAttribute("Test:DoesntHave"),
+            });
+
+            Assert.Equal(AccessDeniedErrorCode, sutResult.Error.Code);
+        }
+
+        [Fact]
+        public void Fails_If_Permission_Is_Null_And_User_Is_Not_Logged_In_And_Have_No_Permissions()
+        {
+            var sutResult = TestResourceFilters(new IResourceFilter[]
+                {
+                    new ServiceAuthorizeAttribute((string) null),
+                },
+                isLoggedIn: false);
+
+            Assert.Equal(NotLoggedInErrorCode, sutResult.Error.Code);
+        }
+
+        [Fact]
+        public void Passes_If_Permission_Is_Null_And_User_Is_Logged_In_And_Have_No_Permissions()
+        {
+            var sutResult = TestResourceFilters(new IResourceFilter[]
+                {
+                    new ServiceAuthorizeAttribute((string) null),
+                },
+                isLoggedIn: true);
+            
+            Assert.Null(sutResult);
+        }
+
+        [Fact]
+        public void Fails_With_AccessDenied_If_User_Is_Logged_In()
+        {
+            var sutResult = TestResourceFilters(new IResourceFilter[]
+                {
+                    new ServiceAuthorizeAttribute("Test:Permission")
+                },
+                isLoggedIn: true);
+
+            Assert.Equal(AccessDeniedErrorCode, sutResult.Error.Code);
+        }
+
+        [Fact]
+        public void Fails_With_NotLoggedIn_If_User_Is_Not_Logged_In()
+        {
+            var sutResult = TestResourceFilters(new IResourceFilter[]
+                {
+                    new ServiceAuthorizeAttribute("Test:Permission")
+                },
+                isLoggedIn: false);
+
+            Assert.Equal(NotLoggedInErrorCode, sutResult.Error.Code);
+        }
+
+        [ReadPermission("Test:ReadPermission")]
+        [UpdatePermission("Test:UpdatePermission")]
+        [DisplayName("Will throw when we set this on constructor's attribute types")]
+        private record TypeWithReadPermissionAttribute;
+
+        [Fact]
+        public void Constructor_With_Type_Uses_Types_ReadPermissionAttribute_As_Permission()
+        {
+            var attr = new ServiceAuthorizeAttribute(typeof(TypeWithReadPermissionAttribute));
+
+            Assert.Equal("Test:ReadPermission", attr.Permission);
+        }
+
+        [Fact]
+        public void Constructor_With_Type_And_AttributeTypes_Tries_To_Find_First_Match_To_Use_As_Permission()
+        {
+            var attr = new CallConstructorWithTypeAndParamsTypeAttribute(typeof(TypeWithReadPermissionAttribute),
+                typeof(InsertPermissionAttribute),
+                typeof(UpdatePermissionAttribute));
+
+            Assert.Equal("Test:UpdatePermission", attr.Permission);
+        }
+
+        [Fact]
+        public void Constructor_With_Type_Throws_If_SourceType_Is_Null()
+        {
+            Assert.Throws<ArgumentNullException>("sourceType", () => new ServiceAuthorizeAttribute(null));
+        }
+
+        [Fact]
+        public void Constructor_With_Type_And_Params_Type_List_Throws_If_SourceType_Is_Null()
+        {
+            Assert.Throws<ArgumentNullException>("attributeTypes", () =>
+                new CallConstructorWithTypeAndParamsTypeAttribute(typeof(TypeWithReadPermissionAttribute)));
+        }
+
+        [Fact]
+        public void Constructor_With_Type_And_Params_Type_List_Throws_If_Attribute_Is_Not_Subclass_Of_PermissionAttributeBase()
+        {
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new CallConstructorWithTypeAndParamsTypeAttribute(typeof(TypeWithReadPermissionAttribute), typeof(DisplayNameAttribute)));
+
+            Assert.Equal(nameof(DisplayNameAttribute) + " is not a subclass of PermissionAttributeBase!", ex.ParamName);
+        }
+
+        private record TypeWithoutAnyAttributes;
+
+        [Fact]
+        public void Constructor_With_Type_Throws_If_There_Are_No_Attributes_To_Use_As_Permission()
+        {
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new CallConstructorWithTypeAndParamsTypeAttribute(typeof(TypeWithoutAnyAttributes), typeof(ReadPermissionAttribute)));
+
+            Assert.Equal("ServiceAuthorize attribute is created with source type of TypeWithoutAnyAttributes" +
+                         ", but it has no ReadPermissionAttribute attribute(s) (Parameter 'sourceType')", ex.Message);
+        }
+
+        [Fact]
+        public void Constructor_With_Type_Throws_With_Joined_Attribute_Names_If_There_Are_No_Attributes_To_Use_As_Permission()
+        {
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new CallConstructorWithTypeAndParamsTypeAttribute(typeof(TypeWithoutAnyAttributes),
+                    typeof(ReadPermissionAttribute),
+                    typeof(UpdatePermissionAttribute)));
+
+            Assert.Equal("ServiceAuthorize attribute is created with source type of TypeWithoutAnyAttributes" +
+                         ", but it has no ReadPermissionAttribute OR UpdatePermissionAttribute attribute(s) (Parameter 'sourceType')", ex.Message);
+        }
+
+        [Fact]
+        public void Constructor_With_Two_Object_Parameters_Joins_Params()
+        {
+            var attr = new ServiceAuthorizeAttribute("Test", "Permission");
+            
+            Assert.Equal("Test:Permission", attr.Permission);
+        }
+
+        [Fact]
+        public void Constructor_With_Three_Object_Parameters_Joins_Params()
+        {
+            var attr = new ServiceAuthorizeAttribute("Test", "Permission", "LastPart");
+            
+            Assert.Equal("Test:Permission:LastPart", attr.Permission);
+        }
+        
+        /// <summary>
+        /// Runs all the <see cref="IResourceFilter"/>'s on a newly created <see cref="HttpContext"/>.
+        /// </summary>
+        /// <param name="testFilters"><see cref="IResourceFilter"/>'s to run.</param>
+        /// <param name="isLoggedIn">Sets if the user is logged in.</param>
+        /// <param name="permissions">Sets the permissions to grant.</param>
+        /// <returns>Returns <see cref="ResourceExecutingContext"/>'s result casted as <see cref="ServiceResponse"/>.</returns>
+        private ServiceResponse TestResourceFilters(IResourceFilter[] testFilters, bool isLoggedIn = true, IEnumerable<string> permissions = null)
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddSingleton<ITextLocalizer, MockTextLocalizer>();
+            serviceCollection.AddSingleton<IPermissionService>(new MockPermissions((perm) => permissions?.Contains(perm) == true));
+
+            var principal = new ClaimsPrincipal(new ClaimsIdentity(Array.Empty<Claim>(), isLoggedIn ? "Authenticated" : ""));
+
+            var httpContext = new DefaultHttpContext()
+            {
+                RequestServices = serviceCollection.BuildServiceProvider(),
+                User = principal
+            };
+
+            var routeData = new RouteData();
+            var actionDescriptor = new ActionDescriptor();
+            var modelStateDictionary = new ModelStateDictionary();
+            var actionContext = new ActionContext(httpContext, routeData, actionDescriptor, modelStateDictionary);
+
+            var filters = new List<IFilterMetadata>(testFilters);
+            var valueProviderFactories = new List<IValueProviderFactory>();
+            var resourceExecutingContext = new ResourceExecutingContext(actionContext, filters, valueProviderFactories);
+
+            foreach (var filter in testFilters)
+                filter.OnResourceExecuting(resourceExecutingContext);
+
+            return (resourceExecutingContext.Result as Result<ServiceResponse>)?.Data;
+        }
+
+        private class OrPermissionSetAttribute : ServiceAuthorizeAttribute
+        {
+            public OrPermissionSetAttribute(string permission, string orPermission, bool setOverride = true) : base(permission)
+            {
+                OrPermission = orPermission;
+                Override = setOverride;
+            }
+        }
+
+        private class CallConstructorWithTypeAndParamsTypeAttribute : ServiceAuthorizeAttribute
+        {
+            public CallConstructorWithTypeAndParamsTypeAttribute(Type sourceType, params Type[] attributeTypes)
+                : base(sourceType, attributeTypes)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
added permission tests for Permission tests for ListRequestHandler, CriteriaFieldExpressionReplacer, and ServiceAuthorizeAttribute.
added MockTextLocalizer, added test rows for ListRequestHandler and the CriteriaFieldExpressionReplacer.
made ServiceAuthorizeAttribute throw the correct error code and message.