### PR TITLE
Add Json Return Type to DynamicScripts

### DIFF
--- a/src/Serenity.Net.Web/DynamicScript/DynamicScript/DynamicScriptManager.cs
+++ b/src/Serenity.Net.Web/DynamicScript/DynamicScript/DynamicScriptManager.cs
@@ -112,17 +112,31 @@
             return hash;
         }
 
-        private IScriptContent EnsureScriptContent(string name, IDynamicScript script)
+        private IScriptContent EnsureScriptContent(string name, IDynamicScript script, bool json)
         {
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
 
-            var cacheKey = "DynamicScript:" + name;
+            var cacheKey = (json ? "DynamicData:" : "DynamicScript:" ) + name;
             if (script is ICacheSuffix ics)
                 cacheKey = cacheKey + ":" + ics.CacheSuffix;
 
             ScriptContent factory() {
-                var content = utf8Encoding.GetBytes(script.GetScript());
+                byte[] content;
+                if (json) {
+                    if(script is IGetScriptData scriptData)
+                    {
+                        content = utf8Encoding.GetBytes(scriptData.GetData()); 
+                    }
+                    else
+                    {
+                        throw new ValidationError(script.GetType().Name + " Doesn't implement " + nameof(IGetScriptData));
+                    }
+                }
+                else
+                {
+                    content = utf8Encoding.GetBytes(script.GetScript());
+                }
                 return new ScriptContent(content, DateTime.UtcNow, content.Length > 4096);
             }
             
@@ -163,12 +177,12 @@
                 script.CheckRights(permissions, localizer);
         }
 
-        public string GetScriptText(string name)
+        public string GetScriptText(string name, bool json)
         {
             if (!registeredScripts.TryGetValue(name, out var script))
                 return null;
 
-            var content = EnsureScriptContent(name, script).Content;
+            var content = EnsureScriptContent(name, script, json).Content;
             return utf8Encoding.GetString(content);
         }
 
@@ -182,14 +196,14 @@
             return name + extension + "?v=" + hash;
         }
 
-        public IScriptContent ReadScriptContent(string name)
+        public IScriptContent ReadScriptContent(string name, bool json)
         {
             if (!registeredScripts.TryGetValue(name, out var script))
                 return null;
 
             script.CheckRights(permissions, localizer);
 
-            return EnsureScriptContent(name, script);
+            return EnsureScriptContent(name, script, json);
         }
 
         public event Action<string> ScriptChanged

--- a/src/Serenity.Net.Web/DynamicScript/DynamicScript/DynamicScriptManager.cs
+++ b/src/Serenity.Net.Web/DynamicScript/DynamicScript/DynamicScriptManager.cs
@@ -117,16 +117,18 @@
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
 
-            var cacheKey = (json ? "DynamicData:" : "DynamicScript:" ) + name;
+            var cacheKey = (json ? "DynamicData:" : "DynamicScript:") + name;
             if (script is ICacheSuffix ics)
                 cacheKey = cacheKey + ":" + ics.CacheSuffix;
 
-            ScriptContent factory() {
+            ScriptContent factory() 
+            {
                 byte[] content;
+                
                 if (json) {
                     if(script is IGetScriptData scriptData)
                     {
-                        content = utf8Encoding.GetBytes(scriptData.GetData()); 
+                        content = utf8Encoding.GetBytes(scriptData.GetScriptData().ToJson()); 
                     }
                     else
                     {

--- a/src/Serenity.Net.Web/DynamicScript/DynamicScript/DynamicScriptMiddleware.cs
+++ b/src/Serenity.Net.Web/DynamicScript/DynamicScript/DynamicScriptMiddleware.cs
@@ -33,7 +33,7 @@ namespace Serenity.Web.Middleware
                 scriptKey = scriptKey[0..^4];
             }
 
-            var json = context.Request.Headers.Accept.FirstOrDefault().Split(", ").Any(x => x == "application/json");
+            var json = context.Request.Headers.Accept.FirstOrDefault() == "application/json";
 
             if(json)
             {

--- a/src/Serenity.Net.Web/DynamicScript/DynamicScript/DynamicScriptMiddleware.cs
+++ b/src/Serenity.Net.Web/DynamicScript/DynamicScript/DynamicScriptMiddleware.cs
@@ -33,16 +33,23 @@ namespace Serenity.Web.Middleware
                 scriptKey = scriptKey[0..^4];
             }
 
-            return ReturnScript(context, scriptKey, contentType);
+            var json = context.Request.Headers.Accept.FirstOrDefault().Split(", ").Any(x => x == "application/json");
+
+            if(json)
+            {
+                contentType = "application/json";
+            }
+
+            return ReturnScript(context, scriptKey, contentType, json);
         }
 
-        public async static Task ReturnScript(HttpContext context, string scriptKey, string contentType)
+        public async static Task ReturnScript(HttpContext context, string scriptKey, string contentType, bool json)
         {
             IScriptContent scriptContent;
             try
             {
                 scriptContent = context.RequestServices.GetRequiredService<IDynamicScriptManager>()
-                    .ReadScriptContent(scriptKey);
+                    .ReadScriptContent(scriptKey, json);
             }
             catch (ValidationError ve)
             {

--- a/src/Serenity.Net.Web/DynamicScript/DynamicScript/DynamicScriptMiddleware.cs
+++ b/src/Serenity.Net.Web/DynamicScript/DynamicScript/DynamicScriptMiddleware.cs
@@ -33,9 +33,9 @@ namespace Serenity.Web.Middleware
                 scriptKey = scriptKey[0..^4];
             }
 
-            var json = context.Request.Headers.Accept.FirstOrDefault() == "application/json";
+            var json = (string)context.Request.Headers.Accept == "application/json";
 
-            if(json)
+            if (json)
             {
                 contentType = "application/json";
             }

--- a/src/Serenity.Net.Web/DynamicScript/DynamicScript/IDynamicScriptManager.cs
+++ b/src/Serenity.Net.Web/DynamicScript/DynamicScript/IDynamicScriptManager.cs
@@ -9,8 +9,8 @@
         Dictionary<string, string> GetRegisteredScripts();
         IEnumerable<string> GetRegisteredScriptNames();
         string GetScriptInclude(string name, string extension = ".js");
-        string GetScriptText(string name);
-        IScriptContent ReadScriptContent(string name);
+        string GetScriptText(string name, bool json = false);
+        IScriptContent ReadScriptContent(string name, bool json = false);
         void IfNotRegistered(string name, Func<IDynamicScript> callback);
         bool IsRegistered(string name);
         void Register(INamedDynamicScript script);

--- a/src/Serenity.Net.Web/DynamicScript/DynamicScript/IGetScriptData.cs
+++ b/src/Serenity.Net.Web/DynamicScript/DynamicScript/IGetScriptData.cs
@@ -2,6 +2,6 @@
 {
     public interface IGetScriptData
     {
-        public string GetData();
+        public object GetScriptData();
     }
 }

--- a/src/Serenity.Net.Web/DynamicScript/DynamicScript/IGetScriptData.cs
+++ b/src/Serenity.Net.Web/DynamicScript/DynamicScript/IGetScriptData.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Serenity.Web
+﻿namespace Serenity.Web
 {
     public interface IGetScriptData
     {

--- a/src/Serenity.Net.Web/DynamicScript/DynamicScript/IGetScriptData.cs
+++ b/src/Serenity.Net.Web/DynamicScript/DynamicScript/IGetScriptData.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Serenity.Web
+{
+    public interface IGetScriptData
+    {
+        public string GetData();
+    }
+}

--- a/src/Serenity.Net.Web/DynamicScript/DynamicScriptTypes/DataScript.cs
+++ b/src/Serenity.Net.Web/DynamicScript/DynamicScriptTypes/DataScript.cs
@@ -1,6 +1,6 @@
 ﻿namespace Serenity.Web
 {
-    public class DataScript : DynamicScript, INamedDynamicScript
+    public class DataScript : DynamicScript, INamedDynamicScript, IGetScriptData
     {
         protected string key;
         protected Func<object> getData;
@@ -16,6 +16,11 @@
         }
 
         public string ScriptName => "RemoteData." + key;
+
+        string IGetScriptData.GetData()
+        {
+            return getData().ToJson();
+        }
 
         public override string GetScript()
         {

--- a/src/Serenity.Net.Web/DynamicScript/DynamicScriptTypes/DataScript.cs
+++ b/src/Serenity.Net.Web/DynamicScript/DynamicScriptTypes/DataScript.cs
@@ -17,9 +17,9 @@
 
         public string ScriptName => "RemoteData." + key;
 
-        string IGetScriptData.GetData()
+        public object GetScriptData()
         {
-            return getData().ToJson();
+            return getData();
         }
 
         public override string GetScript()
@@ -27,7 +27,6 @@
             var data = getData();
             return string.Format(CultureInfo.CurrentCulture, "Q.ScriptData.set({0}, {1});", ScriptName.ToSingleQuoted(), data.ToJson());
         }
-      
     }
 
     public abstract class DataScript<TData> : DataScript

--- a/src/Serenity.Net.Web/DynamicScript/DynamicScriptTypes/LookupScript.cs
+++ b/src/Serenity.Net.Web/DynamicScript/DynamicScriptTypes/LookupScript.cs
@@ -2,7 +2,7 @@
 
 namespace Serenity.Web
 {
-    public abstract class LookupScript : DynamicScript, INamedDynamicScript
+    public abstract class LookupScript : DynamicScript, INamedDynamicScript, IGetScriptData
     {
         private readonly Dictionary<string, object> lookupParams;
 
@@ -12,6 +12,20 @@ namespace Serenity.Web
         }
 
         protected abstract IEnumerable GetItems();
+
+        public string GetData()
+        {
+            var result = new Dictionary<string, object>
+            {
+                { "items", GetItems() },
+            };
+            foreach (var item in LookupParams)
+            {
+                result.Add(item.Key, item.Value);
+            }
+
+            return result.ToJson();
+        }
 
         public override string GetScript()
         {

--- a/src/Serenity.Net.Web/DynamicScript/DynamicScriptTypes/LookupScript.cs
+++ b/src/Serenity.Net.Web/DynamicScript/DynamicScriptTypes/LookupScript.cs
@@ -6,6 +6,8 @@ namespace Serenity.Web
     {
         private readonly Dictionary<string, object> lookupParams;
 
+        public record LookupScriptData(IEnumerable Items, Dictionary<string, object> Params);
+
         protected LookupScript()
         {
             lookupParams = new Dictionary<string, object>();
@@ -13,18 +15,9 @@ namespace Serenity.Web
 
         protected abstract IEnumerable GetItems();
 
-        public string GetData()
+        public object GetScriptData()
         {
-            var result = new Dictionary<string, object>
-            {
-                { "items", GetItems() },
-            };
-            foreach (var item in LookupParams)
-            {
-                result.Add(item.Key, item.Value);
-            }
-
-            return result.ToJson();
+            return new LookupScriptData(GetItems(), LookupParams);
         }
 
         public override string GetScript()

--- a/src/Serenity.Net.Web/DynamicScript/DynamicScriptTypes/RegisteredScripts.cs
+++ b/src/Serenity.Net.Web/DynamicScript/DynamicScriptTypes/RegisteredScripts.cs
@@ -2,7 +2,7 @@
 
 namespace Serenity.Web
 {
-    public class RegisteredScripts : DynamicScript, INamedDynamicScript
+    public class RegisteredScripts : DynamicScript, INamedDynamicScript, IGetScriptData
     {
         private readonly IDynamicScriptManager scriptManager;
 
@@ -12,6 +12,11 @@ namespace Serenity.Web
         {
             Expiration = TimeSpan.FromDays(-1);
             this.scriptManager = scriptManager;
+        }
+
+        public string GetData()
+        {
+            return ToJsonFast(scriptManager.GetRegisteredScripts());
         }
 
         public override string GetScript()

--- a/src/Serenity.Net.Web/DynamicScript/DynamicScriptTypes/RegisteredScripts.cs
+++ b/src/Serenity.Net.Web/DynamicScript/DynamicScriptTypes/RegisteredScripts.cs
@@ -14,9 +14,9 @@ namespace Serenity.Web
             this.scriptManager = scriptManager;
         }
 
-        public string GetData()
+        public object GetScriptData()
         {
-            return ToJsonFast(scriptManager.GetRegisteredScripts());
+            return scriptManager.GetRegisteredScripts();
         }
 
         public override string GetScript()


### PR DESCRIPTION
example LookupScript
```json
{
    "items": [
        {
            "EmployeeID": 2,
            "FullName": "Andrew Fuller"
        },
        {
            "EmployeeID": 9,
            "FullName": "Anne Dodsworth"
        },
    ],
    "idField": "EmployeeID",
    "textField": "FullName"
}
```
example RemoteData
```json
{
    "Username": "admin",
    "DisplayName": "admin",
    "IsAdmin": true,
    "Permissions": {
        "Administration:Security": true,
        "Administration:Translation": true,
    }
}
```
example RegisteredScripts
```json
{
    "Lookup.Northwind.Shipper": "637949582408073162",
    "Columns.Northwind.Shipper": "637949582408073173",
}
```