### PR TITLE
If there are multiple SortOrder columns defined, columns with desc = true are always sorted in front

### DIFF
--- a/src/Serenity.Scripts/corelib/src/ui/datagrid/datagrid.ts
+++ b/src/Serenity.Scripts/corelib/src/ui/datagrid/datagrid.ts
@@ -790,7 +790,7 @@ export class DataGrid<TItem, TOptions> extends Widget<TOptions> implements IData
 
             if (columns.length > 0) {
                 columns.sort(function (x1, y) {
-                    return x1.sortOrder < y.sortOrder ? -1 : (x1.sortOrder > y.sortOrder ? 1 : 0);
+                    return Math.abs(x1.sortOrder) < Math.abs(y.sortOrder) ? -1 : (Math.abs(x1.sortOrder) > Math.abs(y.sortOrder) ? 1 : 0);
                 });
 
                 var list = [];


### PR DESCRIPTION
Columns should be sorted without consideration of sign (negativ sortOrder determines desc order).
The DESC property is added after the sort.