### PR TITLE
export NestedPermissionKeys namespace when generating PermissionKeys

### DIFF
--- a/src/Serenity.Net.CodeGenerator/CodeGeneration/ServerTypings/ServerTypingsGenerator.PermissionKeys.cs
+++ b/src/Serenity.Net.CodeGenerator/CodeGeneration/ServerTypings/ServerTypingsGenerator.PermissionKeys.cs
@@ -34,7 +34,7 @@
                         continue;
 
                     sb.AppendLine();
-                    GeneratePermissionKeysFor(nested, declare: false, module);
+                    GeneratePermissionKeysFor(nested, declare: true, module);
                 }
             });
         }


### PR DESCRIPTION
so you can access nested classes with [NestedPermissionKeys] in Typescript, this should actually fix #5152