### PR TITLE
feat: add cross apply to SqlQuery

### DIFF
--- a/src/Serenity.Net.Data/FluentSql/SqlQuery_Join.cs
+++ b/src/Serenity.Net.Data/FluentSql/SqlQuery_Join.cs
@@ -286,5 +286,32 @@
 
             return Join(join);
         }
+
+        /// <summary>
+        /// Adds a CROSS APPLY to the query
+        /// </summary>
+        /// <param name="subquery">The subquery.</param>
+        /// <param name="alias">The alias.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException">
+        /// alias is null or alias.name is null or empty.
+        /// </exception>
+        public SqlQuery CrossApply(string subquery, IAlias alias)
+        {
+            if (alias == null)
+                throw new ArgumentNullException("alias");
+
+            if (string.IsNullOrEmpty(alias.Name))
+                throw new ArgumentNullException("alias.name");
+
+            var join = new CrossApply(subquery, alias.Name);
+
+            Join(join);
+
+            if (alias as IHaveJoins != null)
+                AliasWithJoins[alias.Name] = alias as IHaveJoins;
+
+            return this;
+        }
     }
 }

--- a/src/Serenity.Net.Data/Join/CrossApply.cs
+++ b/src/Serenity.Net.Data/Join/CrossApply.cs
@@ -12,7 +12,7 @@
         /// <param name="subQuery">Subquery.</param>
         /// <param name="alias">The alias.</param>
         public CrossApply(string subQuery, string alias)
-            : base(null, string.IsNullOrEmpty(subQuery) ? subQuery : "(" + subQuery + ")", alias, null)
+            : base(null, subQuery, alias, null)
         {
         }
 
@@ -23,7 +23,7 @@
         /// <param name="subQuery">Subquery.</param>
         /// <param name="alias">The alias.</param>
         public CrossApply(IDictionary<string, Join> joins, string subQuery, string alias)
-            : base(joins, string.IsNullOrEmpty(subQuery) ? subQuery : "(" + subQuery + ")", alias, null)
+            : base(joins, subQuery, alias, null)
         {
         }
 

--- a/tests/Serenity.Net.Data.Tests/FluentSql/SqlQuery/SqlQuery_Join_CrossApply_Test.cs
+++ b/tests/Serenity.Net.Data.Tests/FluentSql/SqlQuery/SqlQuery_Join_CrossApply_Test.cs
@@ -1,0 +1,23 @@
+﻿namespace Serenity.Tests.Data;
+
+public class SqlQuery_Join_CrossApply_Test
+{
+    [Fact]
+    public void JoinWithCrossApplyWorks()
+    {
+        var subqueryAlias = new Alias("subquery");
+        var query = new SqlQuery()
+            .From("TestTable1")
+            .CrossApply("OPENJSON(TestColumnJson) WITH(Column int '$')", subqueryAlias)
+            .Select("TestColumn")
+            .Select("subquery.Column");
+
+        Assert.Equal(
+            Normalize.Sql(
+                "SELECT TestColumn, subquery.Column FROM TestTable1 CROSS APPLY OPENJSON(TestColumnJson) WITH(Column int '$') subquery"),
+            Normalize.Sql(
+                query.ToString()));
+    }
+
+   
+}


### PR DESCRIPTION
We implemented a Enum Selection List like descriebed in https://github.com/serenity-is/Serenity/issues/4390#issuecomment-735658731 . Now we need to add a quick filter to the grid with Enums defined in this list. Therefor we need to add a Cross Apply to the SQL Query, but it is not implemented in the Fluent SQL SqlQuery.

The SQL Query we need to implement:
```sql
SELECT DISTINCT<all table fields> 
FROM Row1 r1
CROSS APPLY OPENJSON (r1.Enum) WITH (EnumId int '$') c1
WHERE c1.EnumId IN (1,2)
```