### PR TITLE
Q.formatDate cannot parse string with format 'dd.mm.yyyy hh:mm'

### DIFF
--- a/src/Serenity.Scripts/corelib/src/q/formatting.ts
+++ b/src/Serenity.Scripts/corelib/src/q/formatting.ts
@@ -796,7 +796,7 @@ export function parseDate(s: string, dateOrder?: string): any {
         var datePart = parseDate(s.substr(0, s.indexOf(' ')));
         if (!datePart)
             return false;
-        return parseISODateTime(formatDate(datePart, 'yyyy-MM-dd') + 'T' + trim(s.substr(s.indexOf(' ' + 1))));
+        return parseISODateTime(formatDate(datePart, 'yyyy-MM-dd') + 'T' + trim(s.substr(s.indexOf(' ') + 1)));
     }
 
     let dateVal: any;


### PR DESCRIPTION
The error occurs only if the supplied string has the format 'dd.mm.yyyy hh:mm' and the time part is outside of 10:00 - 19:59.