### PR TITLE
Update FormTyping.scriban

### DIFF
--- a/src/Serenity.Net.CodeGenerator/Templates/FormTyping.scriban
+++ b/src/Serenity.Net.CodeGenerator/Templates/FormTyping.scriban
@@ -11,7 +11,7 @@ namespace {{ModuleNamespace}} {
     }
 
     [{{for x in FormFields}}{{if !for.first}},{{end}}
-        ['{{x.PropertyName}}', () => Serenity.{{x.TSEditorType}}]{{end}}{{end}}
+        ['{{x.PropertyName}}', () => Serenity.{{x.TSEditorType}}]{{end}}
     ].forEach(x => Object.defineProperty({{FormClassName}}.prototype, <string>x[0], {
         get: function () {
             return this.w(x[0], (x[1] as any)());


### PR DESCRIPTION
{{if x.Ident != Identity}} was removed earlier, now there is an {{end}} too much.