### PR TITLE
added attribute tabindex="0" to toolbar button 

### DIFF
--- a/packages/corelib/src/ui/widgets/toolbar.ts
+++ b/packages/corelib/src/ui/widgets/toolbar.ts
@@ -131,7 +131,7 @@ export class Toolbar extends Widget<ToolbarOptions> {
     protected createButton(container: JQuery, b: ToolButton) {
         var cssClass = b.cssClass ?? '';
 
-        var btn = $('<div class="tool-button"><div class="button-outer">' +
+        var btn = $('<div class="tool-button" tabindex="0"><div class="button-outer">' +
             '<span class="button-inner"></span></div></div>')
             .appendTo(container);
 


### PR DESCRIPTION
currently toolbar buttons are not keyboard focusable (we cannot access them through TAB or shift+TAB keys), sometimes this add inconvenience to data entry operators who are more keyboard friendly than using mouse. 

