### PR TITLE
Default date format added for upload filename format. Error message for non-secure path is updated. 

### DIFF
--- a/src/Serenity.Net.Core/Helpers/PathHelper.cs
+++ b/src/Serenity.Net.Core/Helpers/PathHelper.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 
 namespace Serenity;
 
@@ -47,7 +47,7 @@ public static class PathHelper
             throw new ArgumentNullException(nameof(relativePath));
 
         if (relativePath.Length > 0 && !IsSecureRelativePath(relativePath))
-            throw new ArgumentOutOfRangeException(nameof(relativePath));
+            throw new ArgumentOutOfRangeException(nameof(relativePath), "Invalid characters in path!");
 
         return Path.Combine(root, relativePath);
     }

--- a/src/Serenity.Net.Services/Upload/UploadFormatting.cs
+++ b/src/Serenity.Net.Services/Upload/UploadFormatting.cs
@@ -1,4 +1,4 @@
-﻿using Serenity.IO;
+using Serenity.IO;
 using Path = System.IO.Path;
 
 namespace Serenity.Web;
@@ -44,7 +44,11 @@ public static class UploadFormatting
         if (string.IsNullOrEmpty(originalName))
             throw new ArgumentNullException(nameof(originalName));
 
-        var formatted = string.Format(options.Format, identity, groupKey, 
+        var formatted = options.Format;
+        if (formatted.Contains("{3}", StringComparison.OrdinalIgnoreCase))
+            formatted = formatted.Replace("{3}", "{3:yyyyMMddhhmmss}");
+
+        formatted = string.Format(formatted, identity, groupKey, 
             TemporaryFileHelper.RandomFileCode(), DateTime.Now,
             Path.GetFileNameWithoutExtension(originalName)) + Path.GetExtension(options.OriginalName);
 


### PR DESCRIPTION
The default date format is `yyyyMMddhhmmss` if not specified.
The exception message for not secure relative path is more clear now.