### PR TITLE
Fix the error when try the update record without selecting the target linkingset property in LinkingSetRelationBehavior

### DIFF
--- a/src/Serenity.Net.Services/RequestHandlers/IntegratedFeatures/LinkingSetRelation/LinkingSetRelationBehavior.cs
+++ b/src/Serenity.Net.Services/RequestHandlers/IntegratedFeatures/LinkingSetRelation/LinkingSetRelationBehavior.cs
@@ -364,7 +364,7 @@ public class LinkingSetRelationBehavior(IDefaultHandlerFactory handlerFactory) :
     /// <inheritdoc/>
     public override void OnAfterSave(ISaveRequestHandler handler)
     {
-        if (Target.AsObject(handler.Row) is not IList newList)
+        if (!handler.Row.IsAssigned(Target) || Target.AsObject(handler.Row) is not IList newList)
             return;
 
         var idField = handler.Row.IdField;


### PR DESCRIPTION
The `OnAfterSave` method in `LinkingSetRelationBehavior.cs` now returns if the `Target` field has not been assigned, preventing potential errors when updating record without selecting the LinkingSetRelation data.