### PR TITLE
fix(RadioButtonEditor): resolve issue with read-only mode not being enforced

### DIFF
--- a/packages/corelib/src/ui/editors/radiobuttoneditor.tsx
+++ b/packages/corelib/src/ui/editors/radiobuttoneditor.tsx
@@ -1,4 +1,4 @@
-﻿import { Enum, Fluent, getCustomAttribute, isPromiseLike, tryGetText } from "../../base";
+import { Enum, Fluent, getCustomAttribute, isPromiseLike, tryGetText } from "../../base";
 import { IReadOnly, IStringValue } from "../../interfaces";
 import { getLookup } from "../../compat";
 import { EnumKeyAttribute } from "../../types/attributes";
@@ -100,11 +100,11 @@ export class RadioButtonEditor<P extends RadioButtonEditorOptions = RadioButtonE
         if (this.get_readOnly() !== value) {
             if (value) {
                 this.element.attr('disabled', 'disabled')
-                    .findFirst('input').attr('disabled', 'disabled');
+                    .findEach('input', el => el.attr('disabled', 'disabled'));
             }
             else {
                 this.element.removeAttr('disabled')
-                    .findFirst('input').removeAttr('disabled');
+                    .findEach('input', el => el.removeAttr('disabled'));
             }
         }
     }


### PR DESCRIPTION
Previously, the RadioButtonEditor component did not correctly respect the read-only state, allowing user interaction when it should have been disabled. This fix ensures that the component properly reflects and enforces the read-only setting.