### PR TITLE
Removed unnecessary isDefaultPrevented condition in PermissionCheckEditor onClick event

### DIFF
--- a/serene/src/Serene.Web/Modules/Administration/UserPermission/PermissionCheckEditor.tsx
+++ b/serene/src/Serene.Web/Modules/Administration/UserPermission/PermissionCheckEditor.tsx
@@ -162,11 +162,10 @@ export class PermissionCheckEditor<P extends PermissionCheckEditorOptions = Perm
     protected override onClick(e: Event, row: number, cell: number): void {
         super.onClick(e, row, cell);
 
-        if (!Fluent.isDefaultPrevented(e))
-            SlickTreeHelper.toggleClick(e, row, cell, this.view, (x: any) => x.Key);
-
         if (Fluent.isDefaultPrevented(e))
             return;
+
+        SlickTreeHelper.toggleClick(e, row, cell, this.view, (x: any) => x.Key);
 
         const target = Fluent(e.target);
         let grant = target.hasClass('grant');


### PR DESCRIPTION
This pull request makes a minor change to the click event logic in the `PermissionCheckEditor` component. The update ensures that the tree toggle action is only executed if the event has not been prevented, clarifying and simplifying the event handling flow.