### PR TITLE
Fix column resize and reorder when using the grid in RTL mode

### DIFF
--- a/packages/sleekgrid/build/build.js
+++ b/packages/sleekgrid/build/build.js
@@ -87,7 +87,7 @@ const compatGrid = {
     entryPoints: ['./src/grid/index.ts'],
     outfile: './dist/compat/slick.grid.js',
     plugins: [globalExternals(/\.\.\/core/, {
-        Slick: ["addCssClass", "applyFormatterResultToCellNode", "basicRegexSanitizer", "columnDefaults", "convertCompatFormatter", "ensureUniqueColumnIds", "escapeHtml", "defaultColumnFormat", "disableSelection", "Draggable", "EventEmitter", "EventData", "formatterContext", "gridDefaults", "GlobalEditorLock", "initColumnProps", "keyCode", "NonDataRow", "parsePx", "preClickClassName", "CellRange", "removeCssClass", "RowCell", "spacerDiv", "titleize"]
+        Slick: ["addCssClass", "applyFormatterResultToCellNode", "basicRegexSanitizer", "columnDefaults", "convertCompatFormatter", "ensureUniqueColumnIds", "escapeHtml", "defaultColumnFormat", "disableSelection", "Draggable", "EventEmitter", "EventData", "formatterContext", "gridDefaults", "GlobalEditorLock", "initColumnProps", "keyCode", "NonDataRow", "parsePx", "preClickClassName", "CellRange", "removeCssClass", "RowCell", "spacerDiv", "titleize", "EditorLock"]
     })]
 }
 

--- a/packages/sleekgrid/css/slick.base.css
+++ b/packages/sleekgrid/css/slick.base.css
@@ -240,6 +240,16 @@
   touch-action: none;
 }
 
+.ltr .slick-resizable-handle {
+  right: -5px;
+  left: auto;
+}
+
+.rtl .slick-resizable-handle {
+  right: auto;
+  left: -5px;
+}
+
 .slick-container.slick-column-resizing * {
   cursor: ew-resize !important;
 }

--- a/packages/sleekgrid/src/grid/column-resizing.tsx
+++ b/packages/sleekgrid/src/grid/column-resizing.tsx
@@ -13,7 +13,7 @@ export function setupColumnResize<TItem>(this: void, { absoluteColMinWidth, cont
     container: HTMLElement,
     getEditorLock: () => EditorLock,
     headerColsElements: HTMLElement[],
-    options: Pick<GridOptions, "forceFitColumns">,
+    options: Pick<GridOptions, "forceFitColumns" | "rtl">,
     removeNode: (node: Element) => void,
 }): void {
     let resizingCell: number, pageX: number, minPageX: number, maxPageX: number;
@@ -48,6 +48,11 @@ export function setupColumnResize<TItem>(this: void, { absoluteColMinWidth, cont
         var dist;
         var thisPageX = e.pageX;
         dist = Math.min(maxPageX, Math.max(minPageX, thisPageX)) - pageX;
+
+        if (options.rtl) {
+            dist = -dist;
+        }
+
         if (isNaN(dist)) {
             return;
         }
@@ -56,7 +61,8 @@ export function setupColumnResize<TItem>(this: void, { absoluteColMinWidth, cont
             cell: resizingCell,
             dist,
             forceFit: options.forceFitColumns,
-            absoluteColMinWidth: absoluteColMinWidth
+            absoluteColMinWidth: absoluteColMinWidth,
+            rtl: options.rtl
         });
         colResizing(resizingCell);
     };
@@ -101,7 +107,8 @@ export function setupColumnResize<TItem>(this: void, { absoluteColMinWidth, cont
             cell: resizingCell,
             pageX,
             absoluteColMinWidth,
-            forceFit: options.forceFitColumns
+            forceFit: options.forceFitColumns,
+            rtl: options.rtl
         }));
         document.addEventListener('mousemove', docMouseMove, { signal: disposer.signal });
         document.addEventListener('mouseup', docMouseUp, { signal: disposer.signal });
@@ -192,12 +199,13 @@ export function autosizeColumns(cols: Column[], availWidth: number, absoluteColM
     return reRender;
 }
 
-function shrinkOrStretchColumn({ absoluteColMinWidth, cols, dist, cell: cell, forceFit }: {
+function shrinkOrStretchColumn({ absoluteColMinWidth, cols, dist, cell: cell, forceFit, rtl }: {
     absoluteColMinWidth: number,
     cols: Column[],
     cell: number,
     dist: number,
-    forceFit: boolean
+    forceFit: boolean,
+    rtl?: boolean
 }): void {
     var c: Column, j: number, x: number, actualMinWidth: number;
 
@@ -220,7 +228,10 @@ function shrinkOrStretchColumn({ absoluteColMinWidth, cols, dist, cell: cell, fo
 
         if (forceFit) {
             x = -dist;
-            for (j = cell + 1; j < cols.length; j++) {
+            const step = rtl ? -1 : 1;
+            const start = rtl ? cell - 1 : cell + 1;
+            const end = rtl ? 0 : cols.length;
+            for (j = start; rtl ? j >= end : j < end; j += step) {
                 c = cols[j];
                 if (c.resizable) {
                     if (x && c.maxWidth && (c.maxWidth - c.previousWidth < x)) {
@@ -253,7 +264,10 @@ function shrinkOrStretchColumn({ absoluteColMinWidth, cols, dist, cell: cell, fo
 
         if (forceFit) {
             x = -dist;
-            for (j = cell + 1; j < cols.length; j++) {
+            const step = rtl ? -1 : 1;
+            const start = rtl ? cell - 1 : cell + 1;
+            const end = rtl ? 0 : cols.length;
+            for (j = start; rtl ? j >= end : j < end; j += step) {
                 c = cols[j];
                 if (c.resizable) {
                     actualMinWidth = Math.max(c.minWidth || 0, absoluteColMinWidth);
@@ -271,19 +285,23 @@ function shrinkOrStretchColumn({ absoluteColMinWidth, cols, dist, cell: cell, fo
     }
 }
 
-function calcMinMaxPageXOnDragStart({ absoluteColMinWidth, cols, cell, forceFit, pageX }: {
+function calcMinMaxPageXOnDragStart({ absoluteColMinWidth, cols, cell, forceFit, pageX, rtl }: {
     absoluteColMinWidth: number,
     cols: Column[],
     cell: number,
     forceFit: boolean,
-    pageX: number
+    pageX: number,
+    rtl?: boolean
 }): { maxPageX: number; minPageX: number; } {
     var shrinkLeewayOnRight = null, stretchLeewayOnRight = null, j: number, c: Column;
     if (forceFit) {
         shrinkLeewayOnRight = 0;
         stretchLeewayOnRight = 0;
         // colums on right affect maxPageX/minPageX
-        for (j = cell + 1; j < cols.length; j++) {
+        const start = rtl ? cell - 1 : cell + 1;
+        const end = rtl ? 0 : cols.length;
+        const step = rtl ? -1 : 1;
+        for (j = start; rtl ? j >= end : j < end; j += step) {
             c = cols[j];
             if (c.resizable) {
                 if (stretchLeewayOnRight != null) {
@@ -298,7 +316,9 @@ function calcMinMaxPageXOnDragStart({ absoluteColMinWidth, cols, cell, forceFit,
         }
     }
     var shrinkLeewayOnLeft = 0, stretchLeewayOnLeft = 0;
-    for (j = 0; j <= cell; j++) {
+    const start = rtl ? cols.length - 1 : 0;
+    const step = rtl ? -1 : 1;
+    for (j = start; rtl ? j >= cell : j <= cell; j += step) {
         // columns on left only affect minPageX
         c = cols[j];
         if (c.resizable) {

--- a/packages/sleekgrid/src/grid/sleekgrid.tsx
+++ b/packages/sleekgrid/src/grid/sleekgrid.tsx
@@ -967,6 +967,7 @@ export class SleekGrid<TItem = any> implements ISleekGrid<TItem> {
         const sortableOptions: any = {
             animation: 50,
             direction: 'horizontal',
+            rtl: this._options.rtl,
             chosenClass: 'slick-header-column-dragging',
             ghostClass: 'slick-sortable-placeholder',
             draggable: '.slick-header-column',

--- a/packages/sleekgrid/test/grid/rtl.spec.ts
+++ b/packages/sleekgrid/test/grid/rtl.spec.ts
@@ -1,0 +1,162 @@
+import { Column } from "../../src/core";
+import { SleekGrid } from "../../src/grid";
+
+const getTestColumns = (): Column[] => ([
+  { id: 'col1', field: 'col1', name: 'Column 1', width: 150, minWidth: 30 },
+  { id: 'col2', field: 'col2', name: 'Column 2', width: 150, minWidth: 30 },
+  { id: 'col3', field: 'col3', name: 'Column 3', width: 150, minWidth: 30 }
+]);
+
+const getTestData = () => ([
+  { col1: 'A1', col2: 'B1', col3: 'C1' },
+  { col1: 'A2', col2: 'B2', col3: 'C2' },
+  { col1: 'A3', col2: 'B3', col3: 'C3' }
+]);
+
+function simulateDrag(
+  element: HTMLElement | Document,
+  startX: number,
+  startY: number,
+  endX: number,
+  endY: number
+): void {
+  const mousedown = new MouseEvent('mousedown', { bubbles: true, clientX: startX, clientY: startY });
+  const mousemove = new MouseEvent('mousemove', { bubbles: true, clientX: endX, clientY: endY });
+  const mouseup = new MouseEvent('mouseup', { bubbles: true, clientX: endX, clientY: endY });
+
+  element.dispatchEvent(mousedown);
+  document.dispatchEvent(mousemove);
+  document.dispatchEvent(mouseup);
+}
+
+function mockOffsetWidth(header: HTMLElement, width: number): void {
+  Object.defineProperty(header, 'offsetWidth', {
+    get: () => width,
+    configurable: true
+  });
+}
+
+describe('RTL Mode', () => {
+  let container: HTMLElement;
+  let grid: SleekGrid;
+  let columns: Column[];
+  let data: any[];
+
+  function createGrid(options: any = {}) {
+    columns = getTestColumns();
+    data = getTestData();
+    const defaultOptions = {
+      enableColumnReorder: true,
+      enableColumnResize: true,
+      rtl: true
+    };
+    grid = new SleekGrid(container, data, columns, {
+      ...defaultOptions,
+      ...options
+    });
+    if (grid.render) grid.render();
+  }
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    container.style.width = '800px';
+    container.style.height = '400px';
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    if (grid && grid.destroy) grid.destroy();
+    if (container.parentNode) container.parentNode.removeChild(container);
+  });
+
+  describe('Column Resize in RTL Mode', () => {
+    it('should increase column width when dragging the resize handle to the left', () => {
+      createGrid({ rtl: true });
+
+      const header = grid.getHeaderColumn(columns[0].id);
+      mockOffsetWidth(header, 150);
+
+      const resizeHandle = header?.querySelector('.slick-resizable-handle') as HTMLElement;
+      expect(resizeHandle).toBeTruthy();
+
+      const initialWidth = columns[0].width;
+
+      const rect = resizeHandle.getBoundingClientRect();
+      const startX = rect.left + rect.width / 2;
+      const startY = rect.top + rect.height / 2;
+
+      // Drag left by 50px
+      simulateDrag(resizeHandle, startX, startY, startX - 50, startY);
+
+      expect(columns[0].width).toBeGreaterThan(initialWidth);
+    });
+
+    it('should decrease column width when dragging the resize handle to the right', () => {
+      createGrid({ rtl: true });
+
+      const header = grid.getHeaderColumn(columns[0].id);
+      mockOffsetWidth(header, 150);
+
+      expect(header).toBeTruthy();
+      const resizeHandle = header?.querySelector('.slick-resizable-handle') as HTMLElement;
+      expect(resizeHandle).toBeTruthy();
+
+      const initialWidth = columns[0].width;
+
+      const rect = resizeHandle.getBoundingClientRect();
+      const startX = rect.left + rect.width / 2;
+      const startY = rect.top + rect.height / 2;
+
+      // Drag right by 50px
+      simulateDrag(resizeHandle, startX, startY, startX + 50, startY);
+
+      expect(columns[0].width).toBeLessThan(initialWidth);
+    });
+
+    it('should respect minimum column width when decreasing (drag right)', () => {
+      createGrid({ rtl: true });
+
+      const header = grid.getHeaderColumn(columns[0].id);
+      mockOffsetWidth(header, 150);
+
+      const resizeHandle = header?.querySelector('.slick-resizable-handle') as HTMLElement;
+      expect(resizeHandle).toBeTruthy();
+
+      const rect = resizeHandle.getBoundingClientRect();
+      const startX = rect.left + rect.width / 2;
+      const startY = rect.top + rect.height / 2;
+      
+      // Drag right by 140px (should stop at minWidth)
+      simulateDrag(resizeHandle, startX, startY, startX + 140, startY);
+
+      expect(columns[0].width).toBe(30);
+    });
+  });
+
+  describe('LTR Regression', () => {
+    it('should behave correctly in LTR mode (drag right increases, drag left decreases)', () => {
+      createGrid({ rtl: false });
+
+      const header = grid.getHeaderColumn(columns[0].id);
+      mockOffsetWidth(header, 150);
+
+      const resizeHandle = header?.querySelector('.slick-resizable-handle') as HTMLElement;
+      expect(resizeHandle).toBeTruthy();
+
+      const initialWidth = columns[0].width;
+
+      const rect = resizeHandle.getBoundingClientRect();
+      const startX = rect.left + rect.width / 2;
+      const startY = rect.top + rect.height / 2;
+
+      // Drag right should increase
+      simulateDrag(resizeHandle, startX, startY, startX + 50, startY);
+      expect(columns[0].width).toBeGreaterThan(initialWidth);
+
+      // Reset width and drag left should decrease
+      columns[0].width = initialWidth;
+      simulateDrag(resizeHandle, startX, startY, startX - 50, startY);
+      expect(columns[0].width).toBeLessThan(initialWidth);
+    });
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/serenity-is/sleekgrid/issues/15

## Summary
This fixes column resize and reorder when using the grid in RTL mode.

## Changes
1. **Resize:** When RTL is on, the drag direction is reversed so dragging left expands the column and dragging right shrinks it.
2. **Resize handle:** Moved the resize handle to the left side in RTL mode (via CSS).
3. **Reorder:** Added `rtl: this._options.rtl` to Sortable options. This needs the `sortablejs-rtl` (the regular SortableJS ignores the `rtl` option).
4. **Build:** Fixed the `EditorLock` error by adding it to the `globalExternals` list.
5. **Tests:** Added `rtl.spec.ts` with tests for RTL resize behavior.

## Does this affect LTR?
All RTL code is wrapped in `if (options.rtl)` checks. When RTL is off, everything works exactly like before. No changes to the original LTR logic.

## Testing
- Added 4 new tests for RTL resize (dragging left/right, minWidth, and LTR regression). All existing tests still pass.
- Used a simple HTML page (with LTR/RTL toggle) for manual testing in Chrome and Firefox. I didn't touch the existing LTR examples. They still work the same.
-  All tests pass in the monorepo.

## demo
https://github.com/user-attachments/assets/5144f128-dec5-43f3-96df-3b6658718b3b

```html
<!DOCTYPE html>
<html>
<head>
  <meta charset="UTF-8">
  <title>SleekGrid RTL Test</title>
  <link rel="stylesheet" href="css/slick.base.css">
  <link rel="stylesheet" href="css/slick.grid.css">
  <style>
    body { font-family: sans-serif; font-size: larger; padding: 20px; }
    #grid { width: 1000px; height: 500px; }
  </style>
</head>
<body>
  <h1>RTL Grid Test – Resize & Reorder</h1>
  <label> <input type="checkbox" id="rtlToggle" checked> RTL Mode </label>
  <div id="grid"></div>

  <script src="wwwroot/index.global.js"></script>
  <script>
    let grid = null;

    const columns = [
      { id: 'col1', name: 'Column 1', field: 'col1', width: 250, minWidth: 100 },
      { id: 'col2', name: 'Column 2', field: 'col2', width: 250, minWidth: 100 },
      { id: 'col3', name: 'Column 3', field: 'col3', width: 250, minWidth: 100 },
    ];

    const data = [
      { col1: 'A1', col2: 'B1', col3: 'C1' },
      { col1: 'A2', col2: 'B2', col3: 'C2' },
      { col1: 'A3', col2: 'B3', col3: 'C3' },
    ];

    function loadSortable(rtl) {
      const existing = document.querySelector('script[data-sortable]');
      if (existing) existing.remove();

      const url = rtl
        ? 'https://cdn.jsdelivr.net/npm/sortablejs-rtl@1.15.7/Sortable.min.js'
        : 'https://cdn.jsdelivr.net/npm/sortablejs@1.15.7/Sortable.min.js';

      return new Promise((resolve) => {
        const script = document.createElement('script');
        script.src = url;
        script.dataset.sortable = 'true';
        script.onload = resolve;
        document.head.appendChild(script);
      });
    }

    function createGrid(rtl) {
      if (grid && grid.destroy) grid.destroy();
      
      const container = document.getElementById('grid');
      container.className = '';
      rtl ? document.documentElement.dir = 'rtl' : document.documentElement.removeAttribute('dir');

      loadSortable(rtl).then(() => {
        setTimeout(() => {
          grid = new Slick.Grid('#grid', data, columns, {
            enableColumnReorder: true,
            enableColumnResize: true,
            rtl: rtl,
          });
        }, 10);
      });
    }

    document.getElementById('rtlToggle').addEventListener('change', function() {
      createGrid(this.checked);
    });

    createGrid(true);
  </script>
</body>
</html>

<!-- $ npx serve . -->
'''