### PR TITLE
Correct RTL drag constraints by swapping shrink/stretch leeways

### DIFF
--- a/packages/sleekgrid/src/grid/column-resizing.tsx
+++ b/packages/sleekgrid/src/grid/column-resizing.tsx
@@ -228,10 +228,7 @@ function shrinkOrStretchColumn({ absoluteColMinWidth, cols, dist, cell: cell, fo
 
         if (forceFit) {
             x = -dist;
-            const step = rtl ? -1 : 1;
-            const start = rtl ? cell - 1 : cell + 1;
-            const end = rtl ? 0 : cols.length;
-            for (j = start; rtl ? j >= end : j < end; j += step) {
+            for (j = cell + 1; j < cols.length; j++) {
                 c = cols[j];
                 if (c.resizable) {
                     if (x && c.maxWidth && (c.maxWidth - c.previousWidth < x)) {
@@ -264,10 +261,7 @@ function shrinkOrStretchColumn({ absoluteColMinWidth, cols, dist, cell: cell, fo
 
         if (forceFit) {
             x = -dist;
-            const step = rtl ? -1 : 1;
-            const start = rtl ? cell - 1 : cell + 1;
-            const end = rtl ? 0 : cols.length;
-            for (j = start; rtl ? j >= end : j < end; j += step) {
+            for (j = cell + 1; j < cols.length; j++) {
                 c = cols[j];
                 if (c.resizable) {
                     actualMinWidth = Math.max(c.minWidth || 0, absoluteColMinWidth);
@@ -298,10 +292,7 @@ function calcMinMaxPageXOnDragStart({ absoluteColMinWidth, cols, cell, forceFit,
         shrinkLeewayOnRight = 0;
         stretchLeewayOnRight = 0;
         // colums on right affect maxPageX/minPageX
-        const start = rtl ? cell - 1 : cell + 1;
-        const end = rtl ? 0 : cols.length;
-        const step = rtl ? -1 : 1;
-        for (j = start; rtl ? j >= end : j < end; j += step) {
+        for (j = cell + 1; j < cols.length; j++) {
             c = cols[j];
             if (c.resizable) {
                 if (stretchLeewayOnRight != null) {
@@ -316,9 +307,7 @@ function calcMinMaxPageXOnDragStart({ absoluteColMinWidth, cols, cell, forceFit,
         }
     }
     var shrinkLeewayOnLeft = 0, stretchLeewayOnLeft = 0;
-    const start = rtl ? cols.length - 1 : 0;
-    const step = rtl ? -1 : 1;
-    for (j = start; rtl ? j >= cell : j <= cell; j += step) {
+    for (j = 0; j <= cell; j++) {
         // columns on left only affect minPageX
         c = cols[j];
         if (c.resizable) {
@@ -345,8 +334,16 @@ function calcMinMaxPageXOnDragStart({ absoluteColMinWidth, cols, cell, forceFit,
         stretchLeewayOnLeft = 100000;
     }
 
-    return {
-        maxPageX: pageX + Math.min(shrinkLeewayOnRight, stretchLeewayOnLeft),
-        minPageX: pageX - Math.min(shrinkLeewayOnLeft, stretchLeewayOnRight)
+    // RTL swaps the directional roles
+    if (rtl) {
+        return {
+            maxPageX: pageX + Math.min(shrinkLeewayOnLeft, stretchLeewayOnRight),
+            minPageX: pageX - Math.min(shrinkLeewayOnRight, stretchLeewayOnLeft)
+        }
+    } else {
+        return {
+            maxPageX: pageX + Math.min(shrinkLeewayOnRight, stretchLeewayOnLeft),
+            minPageX: pageX - Math.min(shrinkLeewayOnLeft, stretchLeewayOnRight)
+        }
     }
 }

--- a/packages/sleekgrid/src/grid/column-resizing.tsx
+++ b/packages/sleekgrid/src/grid/column-resizing.tsx
@@ -61,8 +61,7 @@ export function setupColumnResize<TItem>(this: void, { absoluteColMinWidth, cont
             cell: resizingCell,
             dist,
             forceFit: options.forceFitColumns,
-            absoluteColMinWidth: absoluteColMinWidth,
-            rtl: options.rtl
+            absoluteColMinWidth: absoluteColMinWidth
         });
         colResizing(resizingCell);
     };
@@ -199,13 +198,12 @@ export function autosizeColumns(cols: Column[], availWidth: number, absoluteColM
     return reRender;
 }
 
-function shrinkOrStretchColumn({ absoluteColMinWidth, cols, dist, cell: cell, forceFit, rtl }: {
+function shrinkOrStretchColumn({ absoluteColMinWidth, cols, dist, cell: cell, forceFit }: {
     absoluteColMinWidth: number,
     cols: Column[],
     cell: number,
     dist: number,
-    forceFit: boolean,
-    rtl?: boolean
+    forceFit: boolean
 }): void {
     var c: Column, j: number, x: number, actualMinWidth: number;
 

--- a/packages/sleekgrid/test/grid/rtl.spec.ts
+++ b/packages/sleekgrid/test/grid/rtl.spec.ts
@@ -134,6 +134,51 @@ describe('RTL Mode', () => {
     });
   });
 
+  it('should allow each column expand after column is at minWidth in RTL (raw mouse events)', () => {
+    createGrid({ rtl: true });
+
+    const fireMouseEvent = (type: string, target: EventTarget, clientX: number, clientY: number) => {
+      const event = new MouseEvent(type, { bubbles: true, cancelable: true, clientX, clientY });
+      target.dispatchEvent(event);
+    };
+
+    // Test each column (0, 1, 2)
+    for (let i = 0; i < columns.length; i++) {
+      // Reset column widths to 150 for each test iteration
+      columns.forEach(c => c.width = 150);
+
+      const header = grid.getHeaderColumn(columns[i].id);
+      mockOffsetWidth(header, 150);
+      const resizeHandle = header?.querySelector('.slick-resizable-handle') as HTMLElement;
+      expect(resizeHandle).toBeTruthy();
+
+      let rect = resizeHandle.getBoundingClientRect();
+      let startX = rect.left + rect.width / 2;
+      let startY = rect.top + rect.height / 2;
+
+      // Drag right by 200px should shrink to minWidth (30)
+      fireMouseEvent('mousedown', resizeHandle, startX, startY);
+      fireMouseEvent('mousemove', document, startX + 200, startY);
+      fireMouseEvent('mouseup', document, startX + 200, startY);
+
+      expect(columns[i].width).toBeGreaterThanOrEqual(25);
+      expect(columns[i].width).toBeLessThanOrEqual(45);
+
+      // Drag left by 200px should expand to 230
+      mockOffsetWidth(header, 30);
+      rect = resizeHandle.getBoundingClientRect();
+      startX = rect.left + rect.width / 2;
+      startY = rect.top + rect.height / 2;
+
+      fireMouseEvent('mousedown', resizeHandle, startX, startY);
+      fireMouseEvent('mousemove', document, startX - 200, startY);
+      fireMouseEvent('mouseup', document, startX - 200, startY);
+
+      expect(columns[i].width).toBeGreaterThanOrEqual(220);
+      expect(columns[i].width).toBeLessThanOrEqual(250);
+    }
+  });
+
   describe('LTR Regression', () => {
     it('should behave correctly in LTR mode (drag right increases, drag left decreases)', () => {
       createGrid({ rtl: false });

--- a/packages/sleekgrid/test/grid/rtl.spec.ts
+++ b/packages/sleekgrid/test/grid/rtl.spec.ts
@@ -118,7 +118,7 @@ describe('RTL Mode', () => {
 
       const header = grid.getHeaderColumn(columns[0].id);
       mockOffsetWidth(header, 150);
-
+      
       const resizeHandle = header?.querySelector('.slick-resizable-handle') as HTMLElement;
       expect(resizeHandle).toBeTruthy();
 
@@ -142,13 +142,22 @@ describe('RTL Mode', () => {
       target.dispatchEvent(event);
     };
 
+    // Mock offsetWidth for each header according to its current model width
+    const mockHeadersToCurrentWidths = () => {
+      columns.forEach(col => {
+        const hdr = grid.getHeaderColumn(col.id);
+        if (hdr) mockOffsetWidth(hdr, col.width);
+      });
+    };
+
     // Test each column (0, 1, 2)
     for (let i = 0; i < columns.length; i++) {
-      // Reset column widths to 150 for each test iteration
+      
+      // Reset all column widths to 150
       columns.forEach(c => c.width = 150);
+      mockHeadersToCurrentWidths();
 
       const header = grid.getHeaderColumn(columns[i].id);
-      mockOffsetWidth(header, 150);
       const resizeHandle = header?.querySelector('.slick-resizable-handle') as HTMLElement;
       expect(resizeHandle).toBeTruthy();
 
@@ -156,26 +165,49 @@ describe('RTL Mode', () => {
       let startX = rect.left + rect.width / 2;
       let startY = rect.top + rect.height / 2;
 
-      // Drag right by 200px should shrink to minWidth (30)
+      // Shrink all columns 0..i to minWidth. Total shrink capacity = (i+1) * (150 - 30)
+      const totalShrink = (i + 1) * 120;
       fireMouseEvent('mousedown', resizeHandle, startX, startY);
-      fireMouseEvent('mousemove', document, startX + 200, startY);
-      fireMouseEvent('mouseup', document, startX + 200, startY);
+      fireMouseEvent('mousemove', document, startX + totalShrink, startY);
+      fireMouseEvent('mouseup', document, startX + totalShrink, startY);
 
-      expect(columns[i].width).toBeGreaterThanOrEqual(25);
-      expect(columns[i].width).toBeLessThanOrEqual(45);
+      // All columns 0..i should be near minWidth (30)
+      for (let k = 0; k <= i; k++) {
+        expect(columns[k].width).toBeGreaterThanOrEqual(25);
+        expect(columns[k].width).toBeLessThanOrEqual(45);
+      }
+      // Columns > i remain unchanged (150)
+      for (let k = i + 1; k < columns.length; k++) {
+        expect(columns[k].width).toBeGreaterThanOrEqual(145);
+        expect(columns[k].width).toBeLessThanOrEqual(155);
+      }
 
-      // Drag left by 200px should expand to 230
-      mockOffsetWidth(header, 30);
+      // Update the offsetWidth mock to reflect the current widths
+      mockHeadersToCurrentWidths();
+
+      // Re‑fetch handle position (layout may have changed)
       rect = resizeHandle.getBoundingClientRect();
       startX = rect.left + rect.width / 2;
       startY = rect.top + rect.height / 2;
 
+      // Second drag: expand by dragging left by 200px
       fireMouseEvent('mousedown', resizeHandle, startX, startY);
       fireMouseEvent('mousemove', document, startX - 200, startY);
       fireMouseEvent('mouseup', document, startX - 200, startY);
 
+      // The dragged column (i) should expand to near 230 (220-250)
       expect(columns[i].width).toBeGreaterThanOrEqual(220);
       expect(columns[i].width).toBeLessThanOrEqual(250);
+      // Columns before i stay at minWidth 30 (25-45)
+      for (let k = 0; k < i; k++) {
+        expect(columns[k].width).toBeGreaterThanOrEqual(25);
+        expect(columns[k].width).toBeLessThanOrEqual(45);
+      }
+      // Columns after i stay at 150
+      for (let k = i + 1; k < columns.length; k++) {
+        expect(columns[k].width).toBeGreaterThanOrEqual(145);
+        expect(columns[k].width).toBeLessThanOrEqual(155);
+      }
     }
   });
 


### PR DESCRIPTION
## Problem
Previously, `calcMinMaxPageXOnDragStart` returned the same directional formulas for both LTR and RTL, which caused two issues:
1. Dragging left to stretch a column would incorrectly hit the **opposite block’s shrink capacity**, prematurely blocking the stretch.
2. Dragging left with no `maxWidth` limits would still stop at a seemingly arbitrary width (the finite shrink capacity of the left block).

## Solution
- **Keep the loop bounds unchanged** – the logical split remains the same (similar to versions before #7419, which was cleaner).
- **Swap the return formulas** when `rtl = true` for `maxPageX` and `minPageX`.

## Testing
- Manually tested with `example94-rtl`.
- Added a new test: `should allow each column expand after column is at minWidth in RTL`.

## Demo
Videos showing the behavior before: 
https://github.com/user-attachments/assets/a34fb611-b351-4db8-acfd-3bb9733fbd07
and after the fix:
https://github.com/user-attachments/assets/01979d42-af16-4ae8-abd1-46eb91c826d9
